### PR TITLE
Fix clippy warnings about 'unused_io_amount': use write_all() instead of write() to write into buffers.

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -87,10 +87,10 @@ fn decode(identify: bool, input: &str, output: Option<String>) -> Result<()> {
             writer.write_image_data(&data).unwrap(); // Save
             Ok(())
         } else {
-            std::io::stdout().write(&flif.get_raw_pixels())?;
+            std::io::stdout().write_all(&flif.get_raw_pixels())?;
             Ok(())
         }
-        
+
     }
 }
 

--- a/src/flif/numbers/rac.rs
+++ b/src/flif/numbers/rac.rs
@@ -134,7 +134,7 @@ impl<W: Write> Rac<W> {
         if self.range <= Self::MIN_RANGE {
             // write out the top 8 bits of low
             let byte = (self.low >> Self::MIN_RANGE_BITS) as u8;
-            self.reader.write(&[byte])?;
+            self.reader.write_all(&[byte])?;
             self.low <<= 8;
             self.range <<= 8;
         }
@@ -169,7 +169,7 @@ impl<W: Write> Rac<W> {
         // flush is only ever required if there is data in the top 8 bits (out of 24) of low.
         if self.low >> Self::MIN_RANGE_BITS > 0 {
             let byte = (self.low >> Self::MIN_RANGE_BITS) as u8;
-            self.reader.write(&[byte])?;
+            self.reader.write_all(&[byte])?;
         }
 
         Ok(())


### PR DESCRIPTION
Clippy would refuse to fully check the project otherwise.