### PR TITLE
Print name of the unimplemented transformation in error message.

### DIFF
--- a/src/flif/components/transformations/mod.rs
+++ b/src/flif/components/transformations/mod.rs
@@ -136,9 +136,7 @@ pub fn load_transformations<R: RacRead>(
                 Box::new(Bounds::new(rac, transform, channels, update_table)?)
             }
             _ => {
-                return Err(Error::Unimplemented(
-                    "found unimplemented transformation type",
-                ));
+                return Err(Error::UnimplementedTransformation(id.to_string()));
             }
         };
 

--- a/src/flif/error.rs
+++ b/src/flif/error.rs
@@ -15,6 +15,7 @@ pub enum Error {
     InvalidVarint,
     InvalidOperation(String),
     Unimplemented(&'static str),
+    UnimplementedTransformation(String),
 }
 
 impl error::Error for Error {
@@ -30,6 +31,7 @@ impl error::Error for Error {
             },
             Error::InvalidOperation(_) => "an invalid operation was hit, possibly due to a bug or a bad input file",
             Error::Unimplemented(desc) => desc,
+            Error::UnimplementedTransformation(_) => "a transformation was found which hasn't yet been implemented"
         }
     }
 
@@ -43,6 +45,7 @@ impl error::Error for Error {
             Error::InvalidVarint => None,
             Error::InvalidOperation(_) => None,
             Error::Unimplemented(_) => None,
+            Error::UnimplementedTransformation(_) => None,
         }
     }
 }
@@ -77,6 +80,7 @@ impl fmt::Display for Error {
             ),
             Error::InvalidOperation(ref info) => write!(fmt, "{}", info),
             Error::Unimplemented(desc) => write!(fmt, "{}", desc),
+            Error::UnimplementedTransformation(ref name) => write!(fmt, "found unimplemented transformation type: {}", name),
         }
     }
 }


### PR DESCRIPTION
This is my first ever stab at Rust. I was going to try and implement a transformation but I couldn't even get flif to encode a palette image :1st_place_medal:

In the process I needed to know what transformations I was ending up with. Hence this patch. I think ideally we could run inspect completely without throwing this error at all. Perhaps by including all Transformations in boiler plate with unimplemented methods. Maybe I will try that next, from the transforms branch.

Do you know if there is somewhere with example encodings of images with various parts of the flif spec implemented? I can't find anything.

Anyway good repo here. Thanks for your work! I think Rust and FLIF are really cool, so this is :100: 