### PR TITLE
Non-edge pixels optimization

### DIFF
--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -15,7 +15,6 @@
 //!     let raw_pixels = image.get_raw_pixels();
 //! }
 //! ```
-
 extern crate inflate;
 extern crate num_traits;
 extern crate fnv;
@@ -25,7 +24,7 @@ use std::io::Read;
 use components::header::{Header, SecondHeader};
 use components::metadata::Metadata;
 use components::transformations::Transform;
-use colors::{Channel, ColorSpace, ColorValue, Pixel};
+use colors::ColorSpace;
 pub use error::{Error, Result};
 
 pub use decoder::Decoder;
@@ -33,10 +32,13 @@ pub use decoder::Decoder;
 mod decoder;
 mod numbers;
 mod maniac;
+mod decoding_image;
 pub mod colors;
 
 pub mod components;
 mod error;
+
+use decoding_image::DecodingImage;
 
 pub struct Flif {
     info: FlifInfo,
@@ -62,7 +64,7 @@ impl Flif {
         let height = self.info.header.height;
         let mut data = Vec::with_capacity(n * width * height);
 
-        for vals in self.image_data.data.iter() {
+        for vals in self.image_data.get_data().iter() {
             for channel in self.info.header.channels {
                 data.push(vals[channel] as u8)
             }
@@ -78,113 +80,4 @@ pub struct FlifInfo {
     pub metadata: Vec<Metadata>,
     pub second_header: SecondHeader,
     transform: Box<Transform>,
-}
-
-struct DecodingImage {
-    pub height: usize,
-    pub width: usize,
-    pub channels: ColorSpace,
-    data: Vec<Pixel>,
-}
-
-#[derive(Debug)]
-struct PixelVicinity {
-    pixel: Pixel,
-    chan: Channel,
-    is_rgba: bool,
-
-    left: Option<ColorValue>,
-    left2: Option<ColorValue>,
-    top: Option<ColorValue>,
-    top2: Option<ColorValue>,
-    top_left: Option<ColorValue>,
-    top_right: Option<ColorValue>,
-}
-
-// safety criteria for unsafe methods: `x < self.width` and `y < self.height`
-// and `self.data.len() == self.width*self.height` must be true
-impl DecodingImage {
-    pub fn new(info: &FlifInfo) -> DecodingImage {
-        DecodingImage {
-            height: info.header.height,
-            width: info.header.width,
-            channels: info.header.channels,
-            data: vec![Pixel::default(); info.header.height * info.header.width],
-        }
-    }
-
-    fn get_idx(&self, x: usize, y: usize) -> usize {
-        (self.width * y) + x
-    }
-
-    unsafe fn get_val(&self, x: usize, y: usize, chan: Channel) -> ColorValue {
-        self.data.get_unchecked(self.get_idx(x, y))[chan]
-    }
-
-    unsafe fn get_vicinity(&self, x: usize, y: usize, chan: Channel)
-        -> PixelVicinity
-    {
-        let pixel = *self.data.get_unchecked((self.width * y) + x);
-        let is_rgba = self.channels == ColorSpace::RGBA;
-        let top = if y != 0 {
-            Some(self.get_val(x, y - 1, chan))
-        } else {
-            None
-        };
-        let left = if x != 0 {
-            Some(self.get_val(x - 1, y, chan))
-        } else {
-            None
-        };
-        let left2 = if x > 1 {
-            Some(self.get_val(x - 2, y, chan))
-        } else {
-            None
-        };
-        let top2 = if y > 1 {
-            Some(self.get_val(x, y - 2, chan))
-        } else {
-            None
-        };
-        let top_left = if x != 0 && y != 0 {
-            Some(self.get_val(x - 1, y - 1, chan))
-        } else {
-            None
-        };
-        let top_right = if y != 0 && x + 1 < self.width {
-            Some(self.get_val(x + 1, y - 1, chan))
-        } else {
-            None
-        };
-        PixelVicinity {
-            pixel, chan, is_rgba, left, left2, top, top2, top_left, top_right,
-        }
-    }
-
-    // iterate over all image pixels and call closure for them without any
-    // bound checks
-    pub fn channel_pass<F>(&mut self, chan: Channel, mut f: F) -> Result<()>
-        where F: FnMut(PixelVicinity) -> Result<ColorValue>
-    {
-        // strictly speaking it's redundant, but to be safe
-        assert_eq!(self.data.len(), self.height*self.width);
-        for y in 0..self.height {
-            for x in 0..self.width {
-                // safe because we are sure that x and y inside the image
-                unsafe {
-                    let pix_vic = self.get_vicinity(x, y, chan);
-                    let val = f(pix_vic)?;
-                    let idx = self.get_idx(x, y);
-                    self.data.get_unchecked_mut(idx)[chan] = val;
-                };
-            }
-        }
-        Ok(())
-    }
-
-    pub fn undo_transform(&mut self, transform: &Transform) {
-        for vals in self.data.iter_mut() {
-            transform.undo(vals);
-        }
-    }
 }

--- a/flif/src/maniac/mod.rs
+++ b/flif/src/maniac/mod.rs
@@ -1,5 +1,4 @@
 #![allow(unused)]
-use super::PixelVicinity;
 use colors::{Channel, ColorSpace, ColorValue};
 use DecodingImage;
 use components::transformations::ColorRange;
@@ -11,65 +10,12 @@ use numbers::near_zero::NearZeroCoder;
 use error::*;
 use components::transformations::Transform;
 
+mod pvec;
+pub(crate) use self::pvec::{core_pvec, edge_pvec};
+
 pub struct ManiacTree<'a> {
     update_table: &'a UpdateTable,
     root: Option<ManiacNode<'a>>,
-}
-
-pub(crate) fn build_pvec(prediction: ColorValue, pix_vic: &PixelVicinity)
-    -> [ColorValue; 10]
-{
-    let mut pvals = [0; 10];
-    let mut i = 0;
-
-    let chan = pix_vic.chan;
-    if chan == Channel::Green || chan == Channel::Blue {
-        pvals[i] = pix_vic.pixel[Channel::Red];
-        i += 1;
-    }
-
-    if chan == Channel::Blue {
-        pvals[i] = pix_vic.pixel[Channel::Green];
-        i += 1;
-    }
-
-    if chan != Channel::Alpha && pix_vic.is_rgba {
-        pvals[i] = pix_vic.pixel[Channel::Alpha];
-        i += 1;
-    }
-
-    pvals[i] = prediction;
-
-    let left = pix_vic.left.unwrap_or(0);
-    let top = pix_vic.top.unwrap_or(0);
-    let top_left = pix_vic.top_left.unwrap_or(0);
-
-    // median index
-    pvals[i+1] = match prediction {
-        pred if pred == left + top - top_left => 0,
-        pred if pred == left => 1,
-        pred if pred == top => 2,
-        _ => 0,
-    };
-
-    if let Some(top_left) = pix_vic.top_left {
-        pvals[i+2] = left - top_left;
-        pvals[i+3] = top_left - top;
-    }
-
-    if let Some(top_right) = pix_vic.top_right {
-        pvals[i+4] = top - top_right;
-    }
-
-    if let Some(top2) = pix_vic.top2 {
-        pvals[i+5] = top2 - top;
-    }
-
-    if let Some(left2) = pix_vic.left2 {
-        pvals[i+6] = left2 - left;
-    }
-
-    pvals
 }
 
 impl<'a> ManiacTree<'a> {

--- a/flif/src/maniac/pvec.rs
+++ b/flif/src/maniac/pvec.rs
@@ -1,0 +1,101 @@
+use colors::{Channel, ColorSpace, ColorValue};
+use decoding_image::{CorePixelVicinity, EdgePixelVicinity};
+
+type Pvec = [ColorValue; 11];
+
+pub(crate) fn core_pvec(pred: ColorValue, pvic: &CorePixelVicinity) -> Pvec {
+    let mut pvec = [0; 11];
+    let mut i = 0;
+
+    let chan = pvic.chan;
+    if chan == Channel::Green || chan == Channel::Blue {
+        pvec[i] = pvic.pixel[Channel::Red];
+        i += 1;
+    }
+
+    if chan == Channel::Blue {
+        pvec[i] = pvic.pixel[Channel::Green];
+        i += 1;
+    }
+
+    if chan != Channel::Alpha && pvic.is_rgba {
+        pvec[i] = pvic.pixel[Channel::Alpha];
+        i += 1;
+    }
+
+    pvec[i] = pred;
+
+    let left = pvic.left;
+    let top = pvic.top;
+    let top_left = pvic.top_left;
+
+    // median index
+    pvec[i+1] = match pred {
+        pred if pred == left + top - top_left => 0,
+        pred if pred == left => 1,
+        pred if pred == top => 2,
+        _ => 0,
+    };
+
+    pvec[i+2] = left - top_left;
+    pvec[i+3] = top_left - top;
+    pvec[i+4] = top - pvic.top_right;
+    pvec[i+5] = pvic.top2 - top;
+    pvec[i+6] = pvic.left2 - left;
+
+    pvec
+}
+
+pub(crate) fn edge_pvec(pred: ColorValue, pvic: &EdgePixelVicinity) -> Pvec {
+    let mut pvec = [0; 11];
+    let mut i = 0;
+
+    let chan = pvic.chan;
+    if chan == Channel::Green || chan == Channel::Blue {
+        pvec[i] = pvic.pixel[Channel::Red];
+        i += 1;
+    }
+
+    if chan == Channel::Blue {
+        pvec[i] = pvic.pixel[Channel::Green];
+        i += 1;
+    }
+
+    if chan != Channel::Alpha && pvic.is_rgba {
+        pvec[i] = pvic.pixel[Channel::Alpha];
+        i += 1;
+    }
+
+    pvec[i] = pred;
+
+    let left = pvic.left.unwrap_or(0);
+    let top = pvic.top.unwrap_or(0);
+    let top_left = pvic.top_left.unwrap_or(0);
+
+    // median index
+    pvec[i+1] = match pred {
+        pred if pred == left + top - top_left => 0,
+        pred if pred == left => 1,
+        pred if pred == top => 2,
+        _ => 0,
+    };
+
+    if let Some(top_left) = pvic.top_left {
+        pvec[i+2] = left - top_left;
+        pvec[i+3] = top_left - top;
+    }
+
+    if let Some(top_right) = pvic.top_right {
+        pvec[i+4] = top - top_right;
+    }
+
+    if let Some(top2) = pvic.top2 {
+        pvec[i+5] = top2 - top;
+    }
+
+    if let Some(left2) = pvic.left2 {
+        pvec[i+6] = left2 - left;
+    }
+
+    pvec
+}


### PR DESCRIPTION
As was described in #23 here I've added separate processing of edge and non-edge pixels. it improves performance by ~5% for current codebase. Code become slightly convoluted (partially because I had to pass `maniac` and `rac` to closures) and probably a more elegant variation can be implemented, but my priority for now was to keep unsafe code local to `DecodingImage`.