### PR TITLE
Decoding limits

### DIFF
--- a/flif/src/components/metadata.rs
+++ b/flif/src/components/metadata.rs
@@ -2,6 +2,7 @@ use std::io::Read;
 use error::*;
 use inflate::inflate_bytes;
 use numbers::FlifReadExt;
+use Limits;
 
 #[derive(Copy, Clone, Debug)]
 pub enum ChunkType {
@@ -23,12 +24,20 @@ pub struct Metadata {
 }
 
 impl Metadata {
-    pub(crate) fn all_from_reader<R: Read>(mut reader: R) -> Result<(Vec<Metadata>, u8)> {
-        let mut ret = vec![];
+    pub(crate) fn all_from_reader<R: Read>(mut reader: R, limits: &Limits)
+        -> Result<(Vec<Metadata>, u8)>
+    {
+        let mut ret = Vec::with_capacity(limits.metadata_count);
         let required_type = loop {
-            match Self::from_reader(&mut reader)? {
+            match Self::from_reader(&mut reader, limits)? {
                 MetadataType::Optional(metadata) => ret.push(metadata),
                 MetadataType::Required(byte) => break byte,
+            }
+            if ret.len() > limits.metadata_count {
+                Err(Error::LimitViolation(format!(
+                    "number of metadata entries exceeds limit: {}",
+                    limits.metadata_count,
+                )))?;
             }
         };
 
@@ -39,7 +48,7 @@ impl Metadata {
     /// been read by the main decode function to determine if its optional or not this function will
     /// use the last 3 bytes to determine the metadata type. If in the future this creates a collision
     /// we will have to change the behavior
-    fn from_reader<R: Read>(mut reader: R) -> Result<MetadataType> {
+    fn from_reader<R: Read>(mut reader: R, limits: &Limits) -> Result<MetadataType> {
         let mut header_buf = [0; 4];
 
         header_buf[0] = reader.read_u8()?;
@@ -59,6 +68,12 @@ impl Metadata {
         };
 
         let chunk_size = reader.read_varint()?;
+        if chunk_size > limits.metadata_chunk {
+            Err(Error::LimitViolation(format!(
+                "requested metadata chunk size exceeds limit: {} vs {}",
+                chunk_size, limits.metadata_chunk,
+            )))?;
+        }
         let mut deflated_chunk = vec![0; chunk_size];
         reader.read_exact(&mut deflated_chunk)?;
         let inflated_chunk = inflate_bytes(&deflated_chunk).map_err(Error::InvalidMetadata)?;

--- a/flif/src/decoder.rs
+++ b/flif/src/decoder.rs
@@ -20,7 +20,7 @@ impl<R: Read> Decoder<R> {
         Ok(Decoder { info, rac })
     }
 
-    pub fn new_with_limits(reader: R, limits: Limits) -> Result<Self> {
+    pub fn with_limits(reader: R, limits: Limits) -> Result<Self> {
         let (info, rac) = identify_internal(reader, limits)?;
         Ok(Decoder { info, rac })
     }
@@ -87,10 +87,12 @@ fn identify_internal<R: Read>(mut reader: R, limits: Limits)
     }
 
     // read the metadata chunks
-    let (metadata, non_opt_byte) = Metadata::all_from_reader(&mut reader, &limits)?;
+    let (metadata, non_optional_byte) = Metadata::all_from_reader(
+        &mut reader, &limits
+    )?;
 
-    if non_opt_byte != 0 {
-        return Err(Error::UnknownRequiredMetadata(non_opt_byte));
+    if non_optional_byte != 0 {
+        return Err(Error::UnknownRequiredMetadata(non_optional_byte));
     }
 
     // After this point all values are encoding using the RAC so methods should no longer take

--- a/flif/src/error.rs
+++ b/flif/src/error.rs
@@ -9,6 +9,7 @@ pub type Result<T> = result::Result<T, Error>;
 pub enum Error {
     Io(io::Error),
     InvalidHeader { desc: &'static str },
+    LimitViolation(String),
     UnknownCriticalMetadata([u8; 4]),
     UnknownRequiredMetadata(u8),
     InvalidMetadata(String),
@@ -23,6 +24,7 @@ impl error::Error for Error {
         match *self {
             Error::InvalidHeader { desc } => desc,
             Error::Io(ref err) => err.description(),
+            Error::LimitViolation(_) => "input image violated decoder limits",
             Error::UnknownCriticalMetadata(_) => "encountered an unknown critical metadata",
             Error::UnknownRequiredMetadata(_) => "encountered an unknown required metadata",
             Error::InvalidMetadata(_) => "metadata chunk was not a valid deflate stream",
@@ -39,6 +41,7 @@ impl error::Error for Error {
         match *self {
             Error::InvalidHeader { .. } => None,
             Error::Io(ref err) => Some(err),
+            Error::LimitViolation(_) => None,
             Error::UnknownCriticalMetadata(_) => None,
             Error::UnknownRequiredMetadata(_) => None,
             Error::InvalidMetadata(_) => None,
@@ -61,6 +64,7 @@ impl fmt::Display for Error {
         match *self {
             Error::InvalidHeader { desc } => write!(fmt, "FLIF header was invalid: {}", desc),
             Error::Io(ref err) => write!(fmt, "error reading from stream: {}", err),
+            Error::LimitViolation(ref info) => write!(fmt, "{}", info),
             Error::UnknownCriticalMetadata(ref header) => write!(
                 fmt,
                 "unknown critical metadata header encountered: {}",

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -48,6 +48,10 @@ impl Flif {
         Decoder::new(reader)?.decode_image()
     }
 
+    pub fn decode_with_limits<R: Read>(reader: R, limits: Limits) -> Result<Self> {
+        Decoder::new_with_limits(reader, limits)?.decode_image()
+    }
+
     pub fn info(&self) -> &FlifInfo {
         &self.info
     }
@@ -69,6 +73,27 @@ impl Flif {
         }
 
         data
+    }
+}
+
+/// Limits on input images to prevent OOM based DoS
+#[derive(Copy, Clone ,Debug)]
+pub struct Limits {
+    /// max size of the compressed metadata in bytes (default: 1 MB)
+    pub metadata_chunk: usize,
+    /// max number of metadata entries (default: 8)
+    pub metadata_count: usize,
+    /// max number of pixels: `width * height * frames` (default: 2<sup>26</sup>)
+    pub pixels: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            metadata_chunk: 1<<20,
+            metadata_count: 8,
+            pixels: 1<<26,
+        }
     }
 }
 

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -85,7 +85,7 @@ pub struct Limits {
     pub metadata_count: usize,
     /// max number of pixels: `width * height * frames` (default: 2<sup>26</sup>)
     pub pixels: usize,
-    /// max number of MANIAC nodes (default: 1024)
+    /// max number of MANIAC nodes (default: 4096)
     pub maniac_nodes: usize,
 }
 
@@ -95,7 +95,7 @@ impl Default for Limits {
             metadata_chunk: 1<<20,
             metadata_count: 8,
             pixels: 1<<26,
-            maniac_nodes: 1024,
+            maniac_nodes: 4096,
         }
     }
 }

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -49,7 +49,7 @@ impl Flif {
     }
 
     pub fn decode_with_limits<R: Read>(reader: R, limits: Limits) -> Result<Self> {
-        Decoder::new_with_limits(reader, limits)?.decode_image()
+        Decoder::with_limits(reader, limits)?.decode_image()
     }
 
     pub fn info(&self) -> &FlifInfo {
@@ -85,6 +85,8 @@ pub struct Limits {
     pub metadata_count: usize,
     /// max number of pixels: `width * height * frames` (default: 2<sup>26</sup>)
     pub pixels: usize,
+    /// max number of MANIAC nodes (default: 1024)
+    pub maniac_nodes: usize,
 }
 
 impl Default for Limits {
@@ -93,6 +95,7 @@ impl Default for Limits {
             metadata_chunk: 1<<20,
             metadata_count: 8,
             pixels: 1<<26,
+            maniac_nodes: 1024,
         }
     }
 }


### PR DESCRIPTION
Limits can be configured by providing `Limits` value to new methods. Default values allow maximum size of `DecodingImage`'s data equal to 2^26, which is equal to 512 MB.

It's better to merge this PR first, after it I'll add limits to fuzzing in #26 .