### PR TITLE
restructure maniac tree to use vector storage

### DIFF
--- a/flif/tests/limits.rs
+++ b/flif/tests/limits.rs
@@ -1,0 +1,23 @@
+extern crate flif;
+
+use std::fs::File;
+use std::io::BufReader;
+
+use flif::Error;
+use flif::Flif;
+use flif::Limits;
+
+#[test]
+fn maniac_size_limit() {
+    let file = BufReader::new(File::open("../resources/sea_snail.flif").unwrap());
+    let mut limits: Limits = Default::default();
+    limits.maniac_nodes = 16;
+    match Flif::decode_with_limits(file, limits) {
+        Err(Error::LimitViolation(ref message)) if message.contains("maniac") => {}
+        Err(err) => panic!(
+            "Expected an Error::LimitViolation indicating the maniac tree was too large, got {:?}",
+            err
+        ),
+        _ => panic!("Expected an Error::LimitViolation indicating the maniac tree was too large, got a valid image instead")
+    }
+}


### PR DESCRIPTION
This speeds up the maniac tree by making it more cache-friendly. On my machine this halved the time in the benchmark.

The implementation is still sub-optimal, Unless the maniac tree is perfectly balanced the vector will waste more memory than the previous implementation. The vector also causes bounds checks everywhere and could possibly be optimized to be even more cache friendly.