### PR TITLE
MANIAC optimizations

### DIFF
--- a/flif/benches/decode.rs
+++ b/flif/benches/decode.rs
@@ -13,3 +13,12 @@ fn bench_cutout_full_decode(b: &mut Bencher) {
         test::black_box(raw);
     });
 }
+
+#[bench]
+fn bench_grey_decode(b: &mut Bencher) {
+    let data = include_bytes!("../../resources/road.flif");
+    b.iter(|| {
+        let raw = Flif::decode(data.as_ref()).unwrap().get_raw_pixels();
+        test::black_box(raw);
+    });
+}

--- a/flif/benches/decode.rs
+++ b/flif/benches/decode.rs
@@ -5,15 +5,11 @@ extern crate test;
 use flif::Flif;
 use test::Bencher;
 
-use std::io::{Cursor, Read};
-
 #[bench]
 fn bench_cutout_full_decode(b: &mut Bencher) {
-    let mut data = Vec::new();
-    let mut file = std::fs::File::open("../resources/sea_snail_cutout.flif").unwrap();
-    file.read_to_end(&mut data).unwrap();
+    let data = include_bytes!("../../resources/sea_snail_cutout.flif");
     b.iter(|| {
-        let raw = Flif::decode(Cursor::new(&data)).unwrap().get_raw_pixels();
+        let raw = Flif::decode(data.as_ref()).unwrap().get_raw_pixels();
         test::black_box(raw);
     });
 }

--- a/flif/src/maniac/mod.rs
+++ b/flif/src/maniac/mod.rs
@@ -233,65 +233,48 @@ impl<'a> ManiacTree<'a> {
     ) -> Result<ColorValue> {
         use self::ManiacNode::*;
         let mut node_index = 0;
-        let (val, new_node) = loop {
-            let mut node = InactiveLeaf;
-            ::std::mem::swap(&mut self.nodes[node_index], &mut node);
+        loop {
+            let (lnodes, rnodes) = &mut self.nodes.split_at_mut(node_index + 1);
+            let node = &mut lnodes[node_index];
             match node {
                 Property {
                     id,
                     value,
-                    mut counter,
-                    mut table,
+                    counter,
+                    table,
                 } => {
-                    if counter > 0 {
-                        let val = rac.read_near_zero(min, max, &mut table)?;
-                        counter -= 1;
-                        break (
-                            val,
-                            Property {
-                                id,
-                                value,
-                                counter,
-                                table,
-                            },
-                        );
+                    break if *counter > 0 {
+                        *counter -= 1;
+                        return rac.read_near_zero(min, max, table);
                     } else {
                         let mut left_table = table.clone();
-                        let mut right_table = table;
+                        let mut right_table = table.clone();
 
-                        let val = if pvec[id as usize] > value {
+                        let val = if pvec[*id as usize] > *value {
                             rac.read_near_zero(min, max, &mut left_table)?
                         } else {
                             rac.read_near_zero(min, max, &mut right_table)?
                         };
 
-                        let mut left = InactiveLeaf;
-                        let mut right = InactiveLeaf;
-                        ::std::mem::swap(&mut self.nodes[2 * node_index + 1], &mut left);
-                        ::std::mem::swap(&mut self.nodes[2 * node_index + 2], &mut right);
-                        self.nodes[2 * node_index + 1] = left.activate(left_table);
-                        self.nodes[2 * node_index + 2] = right.activate(right_table);
-                        break (val, Inner { id, value });
+                        rnodes[node_index].activate(left_table);
+                        rnodes[node_index + 1].activate(right_table);
+                        *node = Inner { id: *id, value: *value };
+                        return Ok(val);
                     }
                 }
                 Inner { id, value } => {
-                    ::std::mem::swap(&mut self.nodes[node_index], &mut node);
-                    if pvec[id as usize] > value {
+                    if pvec[*id as usize] > *value {
                         node_index = 2 * node_index + 1;
                     } else {
                         node_index = 2 * node_index + 2;
                     }
                 }
-                Leaf(mut table) => {
-                    let val = rac.read_near_zero(min, max, &mut table)?;
-                    break (val, Leaf(table));
+                Leaf(table) => {
+                    return rac.read_near_zero(min, max, table);
                 }
                 _ => panic!("improperly constructed tree, Inactive node reached during traversal"),
             }
-        };
-
-        self.nodes[node_index] = new_node;
-        Ok(val)
+        }
     }
 
     fn build_prange_vec(channel: Channel, info: &FlifInfo) -> Vec<ColorRange> {
@@ -354,17 +337,17 @@ enum ManiacNode<'a> {
 
 impl<'a> ManiacNode<'a> {
     // return type is temporary, will be some reasonable pixel value
-    pub fn activate(self, table: ChanceTable<'a>) -> Self {
+    pub fn activate(&mut self, table: ChanceTable<'a>) {
         use self::ManiacNode::*;
-        match self {
+        *self = match self {
             InactiveLeaf => Leaf(table),
             InactiveProperty { id, value, counter } => Property {
-                id,
-                value,
-                counter,
-                table,
+                id: *id,
+                value: *value,
+                counter: *counter,
+                table: table,
             },
-            other => other,
+            _ => return,
         }
     }
 }

--- a/flif/src/maniac/mod.rs
+++ b/flif/src/maniac/mod.rs
@@ -243,13 +243,18 @@ impl<'a> ManiacTree<'a> {
                     } else {
                         node_index = 2 * node_index + 2;
                     }
-                },
+                }
                 Leaf(table) => {
                     return rac.read_near_zero(min, max, table);
-                },
+                }
                 node => {
                     let (val, new_node) = match node {
-                        Property { id, value, counter: 0, table } => {
+                        Property {
+                            id,
+                            value,
+                            counter: 0,
+                            table
+                        } => {
                             let mut left_table = table.clone();
                             let mut right_table = table.clone();
 
@@ -261,20 +266,26 @@ impl<'a> ManiacTree<'a> {
 
                             rnodes[node_index].activate(left_table);
                             rnodes[node_index + 1].activate(right_table);
-                            (val, Inner { id: *id, value: *value })
-                        },
+                            (
+                                val,
+                                Inner {
+                                    id: *id,
+                                    value: *value
+                                },
+                            )
+                        }
                         Property { counter, table, .. } => {
                             *counter -= 1;
                             return rac.read_near_zero(min, max, table);
-                        },
+                        }
                         _ => panic!(
                             "improperly constructed tree, \
-                            inactive node reached during traversal"
+                             inactive node reached during traversal"
                         ),
                     };
                     *node = new_node;
                     return Ok(val);
-                },
+                }
             }
         }
     }

--- a/flif/src/maniac/mod.rs
+++ b/flif/src/maniac/mod.rs
@@ -253,7 +253,7 @@ impl<'a> ManiacTree<'a> {
                             id,
                             value,
                             counter: 0,
-                            table
+                            table,
                         } => {
                             let mut left_table = table.clone();
                             let mut right_table = table.clone();
@@ -270,7 +270,7 @@ impl<'a> ManiacTree<'a> {
                                 val,
                                 Inner {
                                     id: *id,
-                                    value: *value
+                                    value: *value,
                                 },
                             )
                         }


### PR DESCRIPTION
Removed all `mem::swap`s, which considering size of `ManiacNode` (which can contain relatively big `ChanceTable`s) is not a cheap operation. This PR results in ~20% improvement.

Also simplified benchmark a bit and added grey benchmark.