### PR TITLE
More optimizations

### DIFF
--- a/flif-cli/Cargo.toml
+++ b/flif-cli/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/dgriffen/flif.rs"
 [dependencies]
 structopt = "0.1"
 structopt-derive = "0.1"
-png = "0.11"
+png = "0.12"
 flif = { version = "0.2", path = "../flif/" }

--- a/flif/src/numbers/chances.rs
+++ b/flif/src/numbers/chances.rs
@@ -31,6 +31,7 @@ impl<'a> ChanceTable<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn get_chance(&self, entry: ChanceTableEntry) -> u16 {
         match entry {
             ChanceTableEntry::Zero => self.zero,
@@ -42,6 +43,7 @@ impl<'a> ChanceTable<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn update_entry(&mut self, bit: bool, entry: ChanceTableEntry) {
         let old_chance = match entry {
             ChanceTableEntry::Zero => &mut self.zero,

--- a/flif/src/numbers/mod.rs
+++ b/flif/src/numbers/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp::{min, max};
+use std::cmp::{max, min};
 use std::io::Read;
 
 use error::Result;

--- a/flif/src/numbers/mod.rs
+++ b/flif/src/numbers/mod.rs
@@ -1,6 +1,7 @@
-use std::io::prelude::*;
+use std::cmp::{min, max};
+use std::io::Read;
 
-use error::*;
+use error::Result;
 use num_traits::{PrimInt, Unsigned};
 
 pub mod chances;
@@ -26,8 +27,7 @@ impl<R: Read> FlifReadExt for R {
     }
 }
 
-pub fn median3<T: PrimInt>(first: T, second: T, third: T) -> T {
-    let mut slice = [first, second, third];
-    slice.sort();
-    slice[1]
+#[inline(always)]
+pub fn median3<T: PrimInt>(a: T, b: T, c: T) -> T {
+    max(min(a, b), min(max(a, b), c))
 }


### PR DESCRIPTION
Small optimizations which give additional 20%.

After this change `perf report` produces the following results:
```
+  29,81%  decode-193e1634  decode-193e16349b64641b  [.] _$LT$flif..numbers..rac..Rac$LT$R$GT$$u20$as$u20$flif..numbers..rac..RacRead$GT$::read::h508eb70fc761b920
+   9,77%  decode-193e1634  decode-193e16349b64641b  [.] _$LT$flif..numbers..rac..Rac$LT$R$GT$$GT$::input::h253f8d0752fff545
+   9,69%  decode-193e1634  decode-193e16349b64641b  [.] flif::numbers::near_zero::read_near_zero_inner::h256a4ce2b265169e
+   8,76%  decode-193e1634  decode-193e16349b64641b  [.] flif::decoding_image::DecodingImage::channel_pass::hb308cc595457d6c5
+   8,73%  decode-193e1634  decode-193e16349b64641b  [.] flif::maniac::ManiacTree::process::h4d320e7bd5217b70
+   6,99%  decode-193e1634  decode-193e16349b64641b  [.] flif::maniac::pvec::core_pvec::h8ca20e326f507b18
+   6,70%  decode-193e1634  decode-193e16349b64641b  [.] flif::numbers::chances::UpdateTable::next_chance::h71ce1347b9944369
+   3,18%  decode-193e1634  decode-193e16349b64641b  [.] core::ptr::drop_in_place::hb237506e6fab0973
+   2,79%  decode-193e1634  decode-193e16349b64641b  [.] flif::decoding_image::DecodingImage::get_core_vicinity::h2b420043a0b71844
+   2,72%  decode-193e1634  decode-193e16349b64641b  [.] _$LT$flif..components..transformations..ycocg..YCoGg$u20$as$u20$flif..components..transformations..Transform$GT$::crange::h2782ff09b64e64de
+   2,43%  decode-193e1634  decode-193e16349b64641b  [.] _$LT$flif..components..transformations..bounds..Bounds$u20$as$u20$flif..components..transformations..Transform$GT$::crange::h392ffb4cea3b89d6
+   2,31%  decode-193e1634  decode-193e16349b64641b  [.] flif::decoder::make_core_guess::h57797d22840f0483
+   1,23%  decode-193e1634  decode-193e16349b64641b  [.] _$LT$R$u20$as$u20$flif..numbers..near_zero..NearZeroCoder$GT$::read_near_zero::ha729b2315a24094f
```