### PR TITLE
Inline based optimization and overflow bug fixes

### DIFF
--- a/flif/src/components/header.rs
+++ b/flif/src/components/header.rs
@@ -29,15 +29,11 @@ pub struct Header {
 
 /// Helper function for reading width, height and num_frames
 fn read_varint<R: Read>(reader: &mut R, delta: u32) -> Result<u32> {
-    reader
-        .read_varint::<u32>()
-        .and_then(|v| {
-            v.checked_add(delta).ok_or_else(|| {
-                Error::LimitViolation(
-                    "number of pixels exceeds limit: overflow".to_string()
-                )
-            })
+    reader.read_varint::<u32>().and_then(|v| {
+        v.checked_add(delta).ok_or_else(|| {
+            Error::LimitViolation("number of pixels exceeds limit: overflow".to_string())
         })
+    })
 }
 
 /// Check if number of pixels uphelds provided limit
@@ -46,23 +42,18 @@ fn check_limit(width: u32, height: u32, frames: u32, limit: u32) -> Result<()> {
         .checked_mul(width)
         .and_then(|val| val.checked_mul(height));
     match pixels {
-        Some(pix) if pix > limit => {
-            Err(Error::LimitViolation(format!(
-                "number of pixels exceeds limit: {}/{}",
-                pix, limit,
-            )))
-        }
-        None => {
-            Err(Error::LimitViolation(
-                "number of pixels exceeds limit: overflow".to_string()
-            ))
-        }
+        Some(pix) if pix > limit => Err(Error::LimitViolation(format!(
+            "number of pixels exceeds limit: {}/{}",
+            pix, limit,
+        ))),
+        None => Err(Error::LimitViolation(
+            "number of pixels exceeds limit: overflow".to_string(),
+        )),
         Some(_) => Ok(()),
     }
 }
 
 impl Header {
-
     pub(crate) fn from_reader<R: Read>(mut reader: R, limits: &Limits) -> Result<Self> {
         // first read in some magic
         let mut magic_buf = [0; 4];

--- a/flif/src/components/header.rs
+++ b/flif/src/components/header.rs
@@ -22,8 +22,8 @@ pub struct Header {
     pub interlaced: bool,
     pub channels: ColorSpace,
     pub bytes_per_channel: BytesPerChannel,
-    pub width: usize,
-    pub height: usize,
+    pub width: u32,
+    pub height: u32,
     pub num_frames: u32,
 }
 
@@ -41,8 +41,7 @@ fn read_varint<R: Read>(reader: &mut R, delta: u32) -> Result<u32> {
 }
 
 /// Check if number of pixels uphelds provided limit
-fn check_limit(width: usize, height: usize, frames: u32, limit: usize) -> Result<()> {
-    let frames = frames as usize;
+fn check_limit(width: u32, height: u32, frames: u32, limit: u32) -> Result<()> {
     let pixels = frames
         .checked_mul(width)
         .and_then(|val| val.checked_mul(height));
@@ -104,8 +103,8 @@ impl Header {
                 desc: "bytes per channel was not a valid value",
             })?,
         };
-        let width = read_varint(&mut reader, 1)? as usize;
-        let height = read_varint(&mut reader, 1)? as usize;
+        let width = read_varint(&mut reader, 1)?;
+        let height = read_varint(&mut reader, 1)?;
 
         let num_frames = if animated {
             read_varint(&mut reader, 2)?

--- a/flif/src/components/metadata.rs
+++ b/flif/src/components/metadata.rs
@@ -29,13 +29,13 @@ impl Metadata {
         mut reader: R,
         limits: &Limits,
     ) -> Result<(Vec<Metadata>, u8)> {
-        let mut ret = Vec::with_capacity(limits.metadata_count);
+        let mut ret = Vec::with_capacity(limits.metadata_count as usize);
         let required_type = loop {
             match Self::from_reader(&mut reader, limits)? {
                 MetadataType::Optional(metadata) => ret.push(metadata),
                 MetadataType::Required(byte) => break byte,
             }
-            if ret.len() > limits.metadata_count {
+            if ret.len() > limits.metadata_count as usize {
                 Err(Error::LimitViolation(format!(
                     "number of metadata entries exceeds limit: {}",
                     limits.metadata_count,
@@ -70,7 +70,7 @@ impl Metadata {
         };
 
         let chunk_size = reader.read_varint()?;
-        if chunk_size > limits.metadata_chunk {
+        if chunk_size > limits.metadata_chunk as usize {
             Err(Error::LimitViolation(format!(
                 "requested metadata chunk size exceeds limit: {} vs {}",
                 chunk_size, limits.metadata_chunk,

--- a/flif/src/decoder.rs
+++ b/flif/src/decoder.rs
@@ -98,8 +98,7 @@ fn identify_internal<R: Read>(mut reader: R, limits: Limits) -> Result<(FlifInfo
         Some(pix) if pix > limits.pixels => {
             Err(Error::LimitViolation(format!(
                 "number of pixels exceeds limit: {}/{}",
-                pix,
-                limits.pixels,
+                pix, limits.pixels,
             )))?;
         }
         None => {

--- a/flif/src/decoder.rs
+++ b/flif/src/decoder.rs
@@ -91,12 +91,25 @@ fn identify_internal<R: Read>(mut reader: R, limits: Limits) -> Result<(FlifInfo
     // read the first header
     let main_header = Header::from_reader(&mut reader)?;
     let frames = main_header.num_frames as usize;
-    frames.checked_mul(main_header.width)
-        .and_then(|val| val.checked_mul(main_header.height))
-        .and_then(|pixels| if pixels > limits.pixels { None } else { Some(()) })
-        .ok_or(Error::LimitViolation(format!(
-            "number of pixels exceeds limit: {}", limits.pixels,
-        )))?;
+    let pixels = frames
+        .checked_mul(main_header.width)
+        .and_then(|val| val.checked_mul(main_header.height));
+    match pixels {
+        Some(pix) if pix > limits.pixels => {
+            Err(Error::LimitViolation(format!(
+                "number of pixels exceeds limit: {}/{}",
+                pix,
+                limits.pixels,
+            )))?;
+        }
+        None => {
+            Err(Error::LimitViolation(format!(
+                "number of pixels exceeds limit: overflow/{}",
+                limits.pixels,
+            )))?;
+        }
+        Some(_) => (),
+    }
 
     // read the metadata chunks
     let (metadata, non_optional_byte) = Metadata::all_from_reader(&mut reader, &limits)?;

--- a/flif/src/decoder.rs
+++ b/flif/src/decoder.rs
@@ -89,26 +89,7 @@ impl<R: Read> Decoder<R> {
 
 fn identify_internal<R: Read>(mut reader: R, limits: Limits) -> Result<(FlifInfo, Rac<R>)> {
     // read the first header
-    let main_header = Header::from_reader(&mut reader)?;
-    let frames = main_header.num_frames as usize;
-    let pixels = frames
-        .checked_mul(main_header.width)
-        .and_then(|val| val.checked_mul(main_header.height));
-    match pixels {
-        Some(pix) if pix > limits.pixels => {
-            Err(Error::LimitViolation(format!(
-                "number of pixels exceeds limit: {}/{}",
-                pix, limits.pixels,
-            )))?;
-        }
-        None => {
-            Err(Error::LimitViolation(format!(
-                "number of pixels exceeds limit: overflow/{}",
-                limits.pixels,
-            )))?;
-        }
-        Some(_) => (),
-    }
+    let main_header = Header::from_reader(&mut reader, &limits)?;
 
     // read the metadata chunks
     let (metadata, non_optional_byte) = Metadata::all_from_reader(&mut reader, &limits)?;

--- a/flif/src/decoding_image.rs
+++ b/flif/src/decoding_image.rs
@@ -115,13 +115,7 @@ impl DecodingImage {
     }
 
     unsafe fn get_core_vicinity(&self, x: u32, y: u32, chan: Channel) -> CorePixelVicinity {
-        debug_assert!(
-            x < self.width - 1
-                && y < self.height
-                && x > 1
-                && y > 1
-                && self.check_data()
-        );
+        debug_assert!(x < self.width - 1 && y < self.height && x > 1 && y > 1 && self.check_data());
         CorePixelVicinity {
             pixel: *self.data.get_unchecked(self.get_idx(x, y)),
             chan,

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -64,7 +64,7 @@ impl Flif {
         };
         let width = self.info.header.width;
         let height = self.info.header.height;
-        let mut data = Vec::with_capacity(n * width * height);
+        let mut data = Vec::with_capacity((n * width * height) as usize);
 
         for vals in self.image_data.get_data().iter() {
             for channel in self.info.header.channels {
@@ -80,13 +80,13 @@ impl Flif {
 #[derive(Copy, Clone, Debug)]
 pub struct Limits {
     /// max size of the compressed metadata in bytes (default: 1 MB)
-    pub metadata_chunk: usize,
+    pub metadata_chunk: u32,
     /// max number of metadata entries (default: 8)
-    pub metadata_count: usize,
-    /// max number of pixels: `width * height * frames` (default: 2<sup>26</sup>)
-    pub pixels: usize,
-    /// max number of MANIAC nodes (default: 2<sup>14</sup>)
-    pub maniac_nodes: usize,
+    pub metadata_count: u32,
+    /// max number of pixels: `width * height * frames` (default: 67M = 2<sup>26</sup>)
+    pub pixels: u32,
+    /// max number of MANIAC nodes (default: 16384 = 2<sup>14</sup>)
+    pub maniac_nodes: u32,
 }
 
 impl Default for Limits {

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -85,7 +85,7 @@ pub struct Limits {
     pub metadata_count: usize,
     /// max number of pixels: `width * height * frames` (default: 2<sup>26</sup>)
     pub pixels: usize,
-    /// max number of MANIAC nodes (default: 4096)
+    /// max number of MANIAC nodes (default: 2<sup>14</sup>)
     pub maniac_nodes: usize,
 }
 
@@ -95,7 +95,7 @@ impl Default for Limits {
             metadata_chunk: 1 << 20,
             metadata_count: 8,
             pixels: 1 << 26,
-            maniac_nodes: 4096,
+            maniac_nodes: 1 << 14,
         }
     }
 }

--- a/flif/src/maniac/mod.rs
+++ b/flif/src/maniac/mod.rs
@@ -109,7 +109,7 @@ impl<'a> ManiacTree<'a> {
                 _ => break,
             };
 
-            if result_vec.len() > limits.maniac_nodes {
+            if result_vec.len() > limits.maniac_nodes as usize {
                 Err(Error::LimitViolation(format!(
                     "number of maniac nodes exceeds limit"
                 )))?;

--- a/flif/src/numbers/near_zero.rs
+++ b/flif/src/numbers/near_zero.rs
@@ -19,16 +19,18 @@ impl<R: RacRead> NearZeroCoder for R {
         max: I,
         context: &mut ChanceTable,
     ) -> Result<I> {
-        if min > I::zero() {
-            Ok(read_near_zero_inner(self, I::zero(), max - min, context)? + min)
+        let (min, max, delta) = if min > I::zero() {
+            (I::zero(), max - min, min)
         } else if max < I::zero() {
-            Ok(read_near_zero_inner(self, min - max, I::zero(), context)? + max)
+            (min - max, I::zero(), max)
         } else {
-            read_near_zero_inner(self, min, max, context)
-        }
+            (min, max, I::zero())
+        };
+        Ok(read_near_zero_inner(self, min, max, context)? + delta)
     }
 }
 
+#[inline(always)]
 fn read_near_zero_inner<R: RacRead, I: PrimInt>(
     read: &mut R,
     min: I,

--- a/flif/src/numbers/near_zero.rs
+++ b/flif/src/numbers/near_zero.rs
@@ -3,6 +3,8 @@ use num_traits::PrimInt;
 use numbers::chances::{ChanceTable, ChanceTableEntry};
 use numbers::rac::RacRead;
 
+use std::cmp;
+
 pub trait NearZeroCoder {
     fn read_near_zero<I: PrimInt>(
         &mut self,
@@ -19,13 +21,9 @@ impl<R: RacRead> NearZeroCoder for R {
         max: I,
         context: &mut ChanceTable,
     ) -> Result<I> {
-        let (min, max, delta) = if min > I::zero() {
-            (I::zero(), max - min, min)
-        } else if max < I::zero() {
-            (min - max, I::zero(), max)
-        } else {
-            (min, max, I::zero())
-        };
+        let delta = cmp::min(max, cmp::max(I::zero(), min));
+        let min = min - delta;
+        let max = max - delta;
         Ok(read_near_zero_inner(self, min, max, context)? + delta)
     }
 }

--- a/flif/src/numbers/rac.rs
+++ b/flif/src/numbers/rac.rs
@@ -57,6 +57,7 @@ impl<R: Read> RacRead for Rac<R> {
         self.get(chance)
     }
 
+    #[inline(always)]
     fn read(&mut self, context: &mut ChanceTable, entry: ChanceTableEntry) -> Result<bool> {
         let chance = context.get_chance(entry);
         let transformed_chance = Self::apply_chance(u32::from(chance), self.range);


### PR DESCRIPTION
This change results in ~10% improvement at the cost of some binary bloat. Additionally I've relaxed limit on number of maniac nodes up to 2^14, which is equivalent to 2 MB of max memory usage (one node takes 128 bytes).

Currently we are approximately 1.5 times slower compared to the `libflif_dec` on my monochrome 5 MP image. (1.9s vs 1.3s)