### PR TITLE
Change pixels limit type from u32 to u64

### DIFF
--- a/flif/src/components/header.rs
+++ b/flif/src/components/header.rs
@@ -37,10 +37,10 @@ fn read_varint<R: Read>(reader: &mut R, delta: u32) -> Result<u32> {
 }
 
 /// Check if number of pixels uphelds provided limit
-fn check_limit(width: u32, height: u32, frames: u32, limit: u32) -> Result<()> {
-    let pixels = frames
-        .checked_mul(width)
-        .and_then(|val| val.checked_mul(height));
+fn check_limit(width: u32, height: u32, frames: u32, limit: u64) -> Result<()> {
+    let pixels = (frames as u64)
+        .checked_mul(width as u64)
+        .and_then(|val| val.checked_mul(height as u64));
     match pixels {
         Some(pix) if pix > limit => Err(Error::LimitViolation(format!(
             "number of pixels exceeds limit: {}/{}",

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -84,7 +84,7 @@ pub struct Limits {
     /// max number of metadata entries (default: 8)
     pub metadata_count: u32,
     /// max number of pixels: `width * height * frames` (default: 67M = 2<sup>26</sup>)
-    pub pixels: u32,
+    pub pixels: u64,
     /// max number of MANIAC nodes (default: 16384 = 2<sup>14</sup>)
     pub maniac_nodes: u32,
 }


### PR DESCRIPTION
I forgot to add this change to the previous PR, but before releasing `v0.3.0` it probably will be nice to change pixels limit from `u32` to `u64` to allow decoder be used with images bigger than 4.3 gigapixels. (not that I think it will be used for this, but who knows...)