### PR TITLE
Pixels rework

### DIFF
--- a/flif/Cargo.toml
+++ b/flif/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "https://docs.rs/flif"
 [dependencies]
 inflate = "0.4"
 num-traits = "0.2"
-fnv = "1"
 
 [dev-dependencies]
 png = "0.12"

--- a/flif/benches/decode.rs
+++ b/flif/benches/decode.rs
@@ -22,3 +22,12 @@ fn bench_grey_decode(b: &mut Bencher) {
         test::black_box(raw);
     });
 }
+
+#[bench]
+fn bench_full(b: &mut Bencher) {
+    let data = include_bytes!("../../resources/invalid_tid.flif");
+    b.iter(|| {
+        let raw = Flif::decode(data.as_ref()).unwrap().get_raw_pixels();
+        test::black_box(raw);
+    });
+}

--- a/flif/benches/decode.rs
+++ b/flif/benches/decode.rs
@@ -9,8 +9,8 @@ use test::Bencher;
 fn bench_cutout_full_decode(b: &mut Bencher) {
     let data = include_bytes!("../../resources/sea_snail_cutout.flif");
     b.iter(|| {
-        let raw = Flif::decode(data.as_ref()).unwrap().get_raw_pixels();
-        test::black_box(raw);
+        let img = Flif::decode(data.as_ref()).unwrap();
+        test::black_box(img.raw());
     });
 }
 
@@ -18,7 +18,7 @@ fn bench_cutout_full_decode(b: &mut Bencher) {
 fn bench_grey_decode(b: &mut Bencher) {
     let data = include_bytes!("../../resources/road.flif");
     b.iter(|| {
-        let raw = Flif::decode(data.as_ref()).unwrap().get_raw_pixels();
-        test::black_box(raw);
+        let img = Flif::decode(data.as_ref()).unwrap();
+        test::black_box(img.raw());
     });
 }

--- a/flif/benches/decode.rs
+++ b/flif/benches/decode.rs
@@ -22,14 +22,3 @@ fn bench_grey_decode(b: &mut Bencher) {
         test::black_box(raw);
     });
 }
-
-/*
-#[bench]
-fn bench_full(b: &mut Bencher) {
-    let data = include_bytes!("../../resources/invalid_tid.flif");
-    b.iter(|| {
-        let raw = Flif::decode(data.as_ref()).unwrap().get_raw_pixels();
-        test::black_box(raw);
-    });
-}
-*/

--- a/flif/benches/decode.rs
+++ b/flif/benches/decode.rs
@@ -23,6 +23,7 @@ fn bench_grey_decode(b: &mut Bencher) {
     });
 }
 
+/*
 #[bench]
 fn bench_full(b: &mut Bencher) {
     let data = include_bytes!("../../resources/invalid_tid.flif");
@@ -31,3 +32,4 @@ fn bench_full(b: &mut Bencher) {
         test::black_box(raw);
     });
 }
+*/

--- a/flif/examples/decode.rs
+++ b/flif/examples/decode.rs
@@ -40,6 +40,6 @@ fn decode_and_write(input: &str, output: &str) {
     let mut writer = encoder.write_header().unwrap();
 
     // Get the raw pixel array of the FLIF image
-    let data = image.get_raw_pixels();
-    writer.write_image_data(&data).unwrap(); // Save
+    let data = image.raw();
+    writer.write_image_data(data).unwrap(); // Save
 }

--- a/flif/src/colors.rs
+++ b/flif/src/colors.rs
@@ -1,7 +1,10 @@
+#![allow(deprecated)]
+// re-export to avoid public API breakage
+pub use pixels::{ColorSpace, ColorValue};
+
 use std::ops::{Index, IndexMut};
 
-pub type ColorValue = i16;
-
+#[deprecated(since="0.3.1")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Channel {
     Red = 0,
@@ -10,13 +13,10 @@ pub enum Channel {
     Alpha = 3,
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
-pub enum ColorSpace {
-    Monochrome = 1,
-    RGB = 3,
-    RGBA = 4,
-}
+#[deprecated(since="0.3.1")]
+pub type Pixel = ChannelSet<ColorValue>;
 
+#[deprecated(since="0.3.1")]
 #[derive(Copy, Clone, Debug)]
 pub struct ChannelSet<T> {
     red: T,
@@ -78,6 +78,7 @@ impl IntoIterator for ColorSpace {
     }
 }
 
+#[deprecated(since="0.3.1")]
 pub struct IntoChannelIter {
     next: Channel,
     length: u8,

--- a/flif/src/colors.rs
+++ b/flif/src/colors.rs
@@ -62,16 +62,6 @@ impl<T> IndexMut<Channel> for ChannelSet<T> {
     }
 }
 
-impl ColorSpace {
-    pub(crate) fn contains_channel(&self, channel: Channel) -> bool {
-        match *self {
-            ColorSpace::Monochrome => channel == Channel::Red,
-            ColorSpace::RGB => channel != Channel::Alpha,
-            _ => true,
-        }
-    }
-}
-
 impl IntoIterator for ColorSpace {
     type Item = Channel;
     type IntoIter = IntoChannelIter;

--- a/flif/src/colors.rs
+++ b/flif/src/colors.rs
@@ -17,8 +17,6 @@ pub enum ColorSpace {
     RGBA = 4,
 }
 
-pub type Pixel = ChannelSet<ColorValue>;
-
 #[derive(Copy, Clone, Debug)]
 pub struct ChannelSet<T> {
     red: T,

--- a/flif/src/components/header.rs
+++ b/flif/src/components/header.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 
 use super::transformations;
 use super::transformations::{Transform, Transformation};
-use colors::ColorSpace;
+use pixels::ColorSpace;
 use error::*;
 use numbers::chances::UpdateTable;
 use numbers::rac::RacRead;

--- a/flif/src/components/header.rs
+++ b/flif/src/components/header.rs
@@ -17,7 +17,7 @@ pub enum BytesPerChannel {
     Two = 2,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Header {
     pub interlaced: bool,
     pub channels: ColorSpace,
@@ -116,7 +116,7 @@ impl Header {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SecondHeader {
     pub bits_per_pixel: Vec<u8>,
     pub alpha_zero: bool,

--- a/flif/src/components/mod.rs
+++ b/flif/src/components/mod.rs
@@ -3,5 +3,5 @@ pub(crate) mod metadata;
 pub(crate) mod transformations;
 
 pub use self::header::{BytesPerChannel, Header, SecondHeader};
-pub use self::metadata::Metadata;
+pub use self::metadata::{Metadata, ChunkType};
 pub use self::transformations::Transformation;

--- a/flif/src/components/transformations/bounds.rs
+++ b/flif/src/components/transformations/bounds.rs
@@ -1,5 +1,5 @@
 use super::Transform;
-use colors::{Channel, ChannelSet, ColorSpace, Pixel};
+use colors::{Channel, ChannelSet, ColorSpace};
 use components::transformations::ColorRange;
 use error::*;
 use numbers::chances::{ChanceTable, UpdateTable};
@@ -39,15 +39,15 @@ impl Bounds {
 }
 
 impl Transform for Bounds {
-    fn undo(&self, pixel: &mut Pixel) {
-        self.previous_transformation.undo(pixel);
+    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] {
+        self.previous_transformation.undo(pixel)
     }
 
     fn range(&self, channel: Channel) -> ColorRange {
         self.ranges[channel]
     }
 
-    fn crange(&self, channel: Channel, values: &Pixel) -> ColorRange {
+    fn crange(&self, channel: Channel, values: [i16; 4]) -> ColorRange {
         if channel == Channel::Red || channel == Channel::Alpha {
             return self.ranges[channel];
         }

--- a/flif/src/components/transformations/channel_compact.rs
+++ b/flif/src/components/transformations/channel_compact.rs
@@ -1,5 +1,5 @@
 use super::Transform;
-use colors::{Channel, ChannelSet, ColorSpace, Pixel};
+use colors::{Channel, ChannelSet, ColorSpace};
 use components::transformations::ColorRange;
 use error::*;
 use numbers::chances::{ChanceTable, UpdateTable};
@@ -45,13 +45,13 @@ impl ChannelCompact {
 }
 
 impl Transform for ChannelCompact {
-    fn undo(&self, _pixel: &mut Pixel) {}
+    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] { pixel }
 
     fn range(&self, channel: Channel) -> ColorRange {
         self.ranges[channel]
     }
 
-    fn crange(&self, channel: Channel, _values: &Pixel) -> ColorRange {
+    fn crange(&self, channel: Channel, _values: [i16; 4]) -> ColorRange {
         self.ranges[channel]
     }
 }

--- a/flif/src/components/transformations/channel_compact.rs
+++ b/flif/src/components/transformations/channel_compact.rs
@@ -1,5 +1,5 @@
 use super::Transform;
-use colors::{Channel, ChannelSet, ColorSpace};
+use pixels::{Rgba, RgbaChannels, ColorSpace};
 use components::transformations::ColorRange;
 use error::*;
 use numbers::chances::{ChanceTable, UpdateTable};
@@ -8,8 +8,8 @@ use numbers::rac::RacRead;
 
 #[derive(Debug)]
 pub struct ChannelCompact {
-    ranges: ChannelSet<ColorRange>,
-    decompacted: ChannelSet<Vec<i16>>,
+    ranges: [ColorRange; 4],
+    decompacted: [Vec<i16>; 4],
 }
 impl ChannelCompact {
     pub fn new<R: RacRead, T: Transform>(
@@ -24,8 +24,9 @@ impl ChannelCompact {
             decompacted: Default::default(),
         };
 
-        for c in channels {
+        for &c in &RgbaChannels::ORDER[..channels as usize] {
             let t_range = transformation.range(c);
+            let c = c as usize;
             t.ranges[c].max = rac.read_near_zero(0, t_range.max - t_range.min, &mut context)?;
             let mut min = t_range.min;
             for i in 0..t.ranges[c].max + 1 {
@@ -45,13 +46,13 @@ impl ChannelCompact {
 }
 
 impl Transform for ChannelCompact {
-    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] { pixel }
+    fn undo(&self, pixel: Rgba) -> Rgba { pixel }
 
-    fn range(&self, channel: Channel) -> ColorRange {
-        self.ranges[channel]
+    fn range(&self, channel: RgbaChannels) -> ColorRange {
+        self.ranges[channel as usize]
     }
 
-    fn crange(&self, channel: Channel, _values: [i16; 4]) -> ColorRange {
-        self.ranges[channel]
+    fn crange(&self, channel: RgbaChannels, _values: Rgba) -> ColorRange {
+        self.ranges[channel as usize]
     }
 }

--- a/flif/src/components/transformations/mod.rs
+++ b/flif/src/components/transformations/mod.rs
@@ -2,7 +2,7 @@ use self::bounds::Bounds;
 use self::channel_compact::ChannelCompact;
 use self::permute_planes::PermutePlanes;
 use self::ycocg::YCoGg;
-use colors::{Channel, ColorSpace, ColorValue, Pixel};
+use colors::{Channel, ColorSpace, ColorValue};
 use error::*;
 use numbers::chances::UpdateTable;
 use numbers::rac::RacRead;
@@ -65,7 +65,7 @@ impl ::std::fmt::Display for Transformation {
 }
 
 pub trait Transform: ::std::fmt::Debug + Send + Sync {
-    fn snap(&self, channel: Channel, pixel: &Pixel, value: ColorValue) -> ColorValue {
+    fn snap(&self, channel: Channel, pixel: [i16; 4], value: ColorValue) -> ColorValue {
         let range = self.crange(channel, pixel);
 
         if value > range.max {
@@ -77,15 +77,15 @@ pub trait Transform: ::std::fmt::Debug + Send + Sync {
         }
     }
 
-    fn undo(&self, pixel: &mut Pixel);
+    fn undo(&self, pixel: [i16; 4]) -> [i16; 4];
 
     fn range(&self, channel: Channel) -> ColorRange;
 
-    fn crange(&self, channel: Channel, values: &Pixel) -> ColorRange;
+    fn crange(&self, channel: Channel, values: [i16; 4]) -> ColorRange;
 }
 
 impl Transform for Box<Transform> {
-    fn undo(&self, pixel: &mut Pixel) {
+    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] {
         (**self).undo(pixel)
     }
 
@@ -93,7 +93,7 @@ impl Transform for Box<Transform> {
         (**self).range(channel)
     }
 
-    fn crange(&self, channel: Channel, values: &Pixel) -> ColorRange {
+    fn crange(&self, channel: Channel, values: [i16; 4]) -> ColorRange {
         (**self).crange(channel, values)
     }
 }
@@ -102,13 +102,13 @@ impl Transform for Box<Transform> {
 struct Orig;
 
 impl Transform for Orig {
-    fn undo(&self, _pixel: &mut Pixel) {}
+    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] { pixel }
 
     fn range(&self, _channel: Channel) -> ColorRange {
         ColorRange { min: 0, max: 255 }
     }
 
-    fn crange(&self, _channel: Channel, _values: &Pixel) -> ColorRange {
+    fn crange(&self, _channel: Channel, _values: [i16; 4]) -> ColorRange {
         ColorRange { min: 0, max: 255 }
     }
 }

--- a/flif/src/components/transformations/mod.rs
+++ b/flif/src/components/transformations/mod.rs
@@ -2,7 +2,7 @@ use self::bounds::Bounds;
 use self::channel_compact::ChannelCompact;
 use self::permute_planes::PermutePlanes;
 use self::ycocg::YCoGg;
-use colors::{Channel, ColorSpace, ColorValue};
+use pixels::{Rgba, RgbaChannels, ColorSpace, ColorValue};
 use error::*;
 use numbers::chances::UpdateTable;
 use numbers::rac::RacRead;
@@ -65,7 +65,7 @@ impl ::std::fmt::Display for Transformation {
 }
 
 pub trait Transform: ::std::fmt::Debug + Send + Sync {
-    fn snap(&self, channel: Channel, pixel: [i16; 4], value: ColorValue) -> ColorValue {
+    fn snap(&self, channel: RgbaChannels, pixel: Rgba, value: ColorValue) -> ColorValue {
         let range = self.crange(channel, pixel);
 
         if value > range.max {
@@ -77,23 +77,23 @@ pub trait Transform: ::std::fmt::Debug + Send + Sync {
         }
     }
 
-    fn undo(&self, pixel: [i16; 4]) -> [i16; 4];
+    fn undo(&self, pixel: Rgba) -> Rgba;
 
-    fn range(&self, channel: Channel) -> ColorRange;
+    fn range(&self, channel: RgbaChannels) -> ColorRange;
 
-    fn crange(&self, channel: Channel, values: [i16; 4]) -> ColorRange;
+    fn crange(&self, channel: RgbaChannels, values: Rgba) -> ColorRange;
 }
 
 impl Transform for Box<Transform> {
-    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] {
+    fn undo(&self, pixel: Rgba) -> Rgba {
         (**self).undo(pixel)
     }
 
-    fn range(&self, channel: Channel) -> ColorRange {
+    fn range(&self, channel: RgbaChannels) -> ColorRange {
         (**self).range(channel)
     }
 
-    fn crange(&self, channel: Channel, values: [i16; 4]) -> ColorRange {
+    fn crange(&self, channel: RgbaChannels, values: Rgba) -> ColorRange {
         (**self).crange(channel, values)
     }
 }
@@ -102,13 +102,13 @@ impl Transform for Box<Transform> {
 struct Orig;
 
 impl Transform for Orig {
-    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] { pixel }
+    fn undo(&self, pixel: Rgba) -> Rgba { pixel }
 
-    fn range(&self, _channel: Channel) -> ColorRange {
+    fn range(&self, _channel: RgbaChannels) -> ColorRange {
         ColorRange { min: 0, max: 255 }
     }
 
-    fn crange(&self, _channel: Channel, _values: [i16; 4]) -> ColorRange {
+    fn crange(&self, _channel: RgbaChannels, _values: Rgba) -> ColorRange {
         ColorRange { min: 0, max: 255 }
     }
 }

--- a/flif/src/components/transformations/permute_planes.rs
+++ b/flif/src/components/transformations/permute_planes.rs
@@ -1,6 +1,6 @@
 use super::Transform;
-use colors::Channel;
 use components::transformations::ColorRange;
+use pixels::{Rgba, RgbaChannels};
 
 #[derive(Debug)]
 pub struct PermutePlanes {
@@ -10,9 +10,9 @@ pub struct PermutePlanes {
 impl PermutePlanes {
     pub fn new<T: Transform>(transformation: T) -> PermutePlanes {
         let max_iter = [
-            transformation.range(Channel::Red).max,
-            transformation.range(Channel::Green).max,
-            transformation.range(Channel::Blue).max,
+            transformation.range(RgbaChannels::Red).max,
+            transformation.range(RgbaChannels::Green).max,
+            transformation.range(RgbaChannels::Blue).max,
         ];
 
         let old_max = max_iter.iter().max().unwrap();
@@ -22,18 +22,18 @@ impl PermutePlanes {
 }
 
 impl Transform for PermutePlanes {
-    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] { pixel }
+    fn undo(&self, pixel: Rgba) -> Rgba { pixel }
 
-    fn range(&self, channel: Channel) -> ColorRange {
+    fn range(&self, channel: RgbaChannels) -> ColorRange {
         let min = match channel {
-            Channel::Red => 0,
+            RgbaChannels::Red => 0,
             _ => -self.max,
         };
 
         ColorRange { min, max: self.max }
     }
 
-    fn crange(&self, _channel: Channel, _values: [i16; 4]) -> ColorRange {
+    fn crange(&self, _channel: RgbaChannels, _values: Rgba) -> ColorRange {
         unimplemented!()
     }
 }

--- a/flif/src/components/transformations/permute_planes.rs
+++ b/flif/src/components/transformations/permute_planes.rs
@@ -1,5 +1,5 @@
 use super::Transform;
-use colors::{Channel, Pixel};
+use colors::Channel;
 use components::transformations::ColorRange;
 
 #[derive(Debug)]
@@ -22,7 +22,7 @@ impl PermutePlanes {
 }
 
 impl Transform for PermutePlanes {
-    fn undo(&self, _pixel: &mut Pixel) {}
+    fn undo(&self, pixel: [i16; 4]) -> [i16; 4] { pixel }
 
     fn range(&self, channel: Channel) -> ColorRange {
         let min = match channel {
@@ -33,7 +33,7 @@ impl Transform for PermutePlanes {
         ColorRange { min, max: self.max }
     }
 
-    fn crange(&self, _channel: Channel, _values: &Pixel) -> ColorRange {
+    fn crange(&self, _channel: Channel, _values: [i16; 4]) -> ColorRange {
         unimplemented!()
     }
 }

--- a/flif/src/decoder.rs
+++ b/flif/src/decoder.rs
@@ -7,7 +7,7 @@ use pixels::{Greyscale, Rgb, Rgba};
 use error::*;
 use numbers::chances::UpdateTable;
 use numbers::rac::Rac;
-use colors::ColorSpace;
+use pixels::ColorSpace;
 use Limits;
 
 pub struct Decoder<R: Read> {

--- a/flif/src/decoder.rs
+++ b/flif/src/decoder.rs
@@ -1,13 +1,10 @@
 use std::io::Read;
 
 use super::{Flif, FlifInfo, Metadata};
-use colors::{Channel, ChannelSet};
 use components::header::{BytesPerChannel, Header, SecondHeader};
-use decoding_image::{CorePixelVicinity, DecodingImage, EdgePixelVicinity};
+use decoding_image::{DecodingImage, Greyscale};
 use error::*;
-use maniac::{core_pvec, edge_pvec, ManiacTree};
 use numbers::chances::UpdateTable;
-use numbers::median3;
 use numbers::rac::Rac;
 use Limits;
 
@@ -62,27 +59,14 @@ impl<R: Read> Decoder<R> {
             self.info.second_header.alpha_divisor,
             self.info.second_header.cutoff,
         );
-        let mut maniac_vec: ChannelSet<Option<ManiacTree>> = Default::default();
-        for channel in self.info.header.channels {
-            let range = self.info.transform.range(channel);
-            if range.min == range.max {
-                maniac_vec[channel] = None;
-            } else {
-                let tree = ManiacTree::new(
-                    &mut self.rac,
-                    channel,
-                    &self.info,
-                    &update_table,
-                    &self.limits,
-                )?;
-                maniac_vec[channel] = Some(tree);
-            }
-        }
 
-        let image_data = non_interlaced_pixels(&mut self.rac, &self.info, &mut maniac_vec)?;
+        let raw = DecodingImage::<Greyscale, _>::new(
+            &self.info, &mut self.rac, &self.limits, &update_table
+        )?.process()?;
+
         Ok(Flif {
             info: self.info,
-            image_data,
+            raw,
         })
     }
 }
@@ -115,92 +99,4 @@ fn identify_internal<R: Read>(mut reader: R, limits: Limits) -> Result<(FlifInfo
     ))
 }
 
-const CHANNEL_ORDER: [Channel; 4] = [Channel::Alpha, Channel::Red, Channel::Green, Channel::Blue];
-
-fn non_interlaced_pixels<R: Read>(
-    rac: &mut Rac<R>,
-    info: &FlifInfo,
-    maniac: &mut ChannelSet<Option<ManiacTree>>,
-) -> Result<DecodingImage> {
-    let mut image = DecodingImage::new(info);
-    for c in CHANNEL_ORDER
-        .iter()
-        .filter(|c| info.header.channels.contains_channel(**c))
-        .cloned()
-    {
-        image.channel_pass(
-            c,
-            maniac,
-            rac,
-            |pix_vic, maniac, rac| {
-                let guess = make_edge_guess(info, &pix_vic);
-                let range = info.transform.crange(c, &pix_vic.pixel);
-                let snap = info.transform.snap(c, &pix_vic.pixel, guess);
-                let pvec = edge_pvec(snap, &pix_vic);
-
-                if let Some(ref mut maniac) = maniac[c] {
-                    maniac.process(rac, &pvec, snap, range.min, range.max)
-                } else {
-                    Ok(range.min)
-                }
-            },
-            |pix_vic, maniac, rac| {
-                let guess = make_core_guess(&pix_vic);
-                let range = info.transform.crange(c, &pix_vic.pixel);
-                let snap = info.transform.snap(c, &pix_vic.pixel, guess);
-                let pvec = core_pvec(snap, &pix_vic);
-
-                if let Some(ref mut maniac) = maniac[c] {
-                    maniac.process(rac, &pvec, snap, range.min, range.max)
-                } else {
-                    Ok(range.min)
-                }
-            },
-        )?;
-    }
-
-    image.undo_transform(&info.transform);
-
-    Ok(image)
-}
-
-fn make_core_guess(pix_vic: &CorePixelVicinity) -> i16 {
-    let left = pix_vic.left;
-    let top = pix_vic.top;
-    let top_left = pix_vic.top_left;
-
-    median3(left + top - top_left, left, top)
-}
-
-fn make_edge_guess(info: &FlifInfo, pix_vic: &EdgePixelVicinity) -> i16 {
-    let transformation = &info.transform;
-    let chan = pix_vic.chan;
-    let left = if let Some(val) = pix_vic.left {
-        val
-    } else if let Some(val) = pix_vic.top {
-        val
-    } else if info.second_header.alpha_zero
-        && chan != Channel::Alpha
-        && pix_vic.pixel[Channel::Alpha] == 0
-    {
-        (transformation.range(chan).min + transformation.range(chan).max) / 2
-    } else {
-        transformation.range(chan).min
-    };
-
-    let top = if let Some(val) = pix_vic.top {
-        val
-    } else {
-        left
-    };
-
-    let top_left = if let Some(val) = pix_vic.top_left {
-        val
-    } else if let Some(val) = pix_vic.top {
-        val
-    } else {
-        left
-    };
-
-    median3(left + top - top_left, left, top)
-}
+//const CHANNEL_ORDER: [Channel; 4] = [Channel::Alpha, Channel::Red, Channel::Green, Channel::Blue];

--- a/flif/src/decoding_image.rs
+++ b/flif/src/decoding_image.rs
@@ -1,27 +1,109 @@
 use std::io::Read;
 
-use colors::{Channel, ChannelSet, ColorSpace, ColorValue, Pixel};
+use colors::{Channel, ColorValue};
 use components::transformations::Transform;
 pub use error::{Error, Result};
-use maniac::ManiacTree;
+use maniac::{core_pvec, edge_pvec, ManiacTree};
 use numbers::rac::Rac;
-use FlifInfo;
+use numbers::median3;
+use numbers::chances::UpdateTable;
+use {FlifInfo, Limits};
 
 pub use decoder::Decoder;
 
-pub(crate) struct DecodingImage {
+
+pub trait ChannelsTrait {
+    fn as_channel(&self) -> Channel;
+    fn from_channel(chan: Channel) -> Self;
+    fn is_alpha(&self) -> bool;
+}
+
+pub trait PixelTrait: Default + Copy {
+    type Channels: ChannelsTrait + Copy;
+    type ChanOrder: AsRef<[Self::Channels]>;
+
+    fn is_rgba() -> bool;
+    fn get_value(&self, chan: Self::Channels) -> ColorValue;
+    fn set_value(&mut self, val: ColorValue, chan: Self::Channels);
+    /// Return if alpha channel equals to zero. For non-RGBA images always
+    /// returns `false`.
+    fn is_alpha_zero(&self) -> bool;
+
+    /// Return red value if chan is green or blue. Always None for greyscale.
+    fn get_red_pvec(&self, chan: Self::Channels) -> Option<ColorValue>;
+    /// Return green value if chan is blue. Always None for greyscale.
+    fn get_green_pvec(&self, chan: Self::Channels) -> Option<ColorValue>;
+    /// Return alpha value if chan is not alpha. Always None for non-RGBA.
+    fn get_alpha_pvec(&self, chan: Self::Channels) -> Option<ColorValue>;
+
+    fn to_rgba(&self) -> [i16; 4];
+    fn get_chan_order() -> Self::ChanOrder;
+    fn size() -> usize;
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Greyscale(i16);
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GreyChannels;
+
+impl ChannelsTrait for GreyChannels {
+    fn as_channel(&self) -> Channel { Channel::Red }
+    fn from_channel(chan: Channel) -> Self {
+        match chan {
+            Channel::Red => GreyChannels,
+            _ => panic!("invalid cahnnel"),
+        }
+    }
+    fn is_alpha(&self) -> bool { false }
+}
+
+impl PixelTrait for Greyscale {
+    type Channels = GreyChannels;
+    type ChanOrder = [GreyChannels; 1];
+
+    #[inline(always)]
+    fn is_rgba() -> bool { false }
+    #[inline(always)]
+    fn get_value(&self, _chan: Self::Channels) -> ColorValue { self.0 }
+    #[inline(always)]
+    fn set_value(&mut self, val: ColorValue, _chan: Self::Channels) {
+        self.0 = val;
+    }
+    #[inline(always)]
+    fn is_alpha_zero(&self) -> bool { false }
+    #[inline(always)]
+    fn get_red_pvec(&self, _chan: Self::Channels) -> Option<ColorValue> { None }
+    #[inline(always)]
+    fn get_green_pvec(&self, _chan: Self::Channels) -> Option<ColorValue> {
+        None
+    }
+    #[inline(always)]
+    fn get_alpha_pvec(&self, _chan: Self::Channels) -> Option<ColorValue> {
+        None
+    }
+    #[inline(always)]
+    fn to_rgba(&self) -> [i16; 4] { [self.0, 0, 0, 0] }
+    #[inline(always)]
+    fn get_chan_order() -> Self::ChanOrder { [GreyChannels] }
+    #[inline(always)]
+    fn size() -> usize { 1 }
+}
+
+pub(crate) struct DecodingImage<'a, P: PixelTrait, R: Read + 'a> {
     height: u32,
     width: u32,
-    channels: ColorSpace,
-    data: Vec<Pixel>,
+    info: &'a FlifInfo,
+    rac: &'a mut Rac<R>,
+    update_table: &'a UpdateTable,
+    limits: &'a Limits,
+    data: Vec<P>,
 }
 
 #[derive(Debug)]
-pub(crate) struct EdgePixelVicinity {
-    pub pixel: Pixel,
-    pub chan: Channel,
-    pub is_rgba: bool,
-
+pub(crate) struct EdgePixelVicinity<P: PixelTrait> {
+    pub pixel: P,
+    pub chan: P::Channels,
     pub left: Option<ColorValue>,
     pub left2: Option<ColorValue>,
     pub top: Option<ColorValue>,
@@ -31,11 +113,9 @@ pub(crate) struct EdgePixelVicinity {
 }
 
 #[derive(Debug)]
-pub(crate) struct CorePixelVicinity {
-    pub pixel: Pixel,
-    pub chan: Channel,
-    pub is_rgba: bool,
-
+pub(crate) struct CorePixelVicinity<P: PixelTrait> {
+    pub pixel: P,
+    pub chan: P::Channels,
     pub left: ColorValue,
     pub left2: ColorValue,
     pub top: ColorValue,
@@ -44,18 +124,23 @@ pub(crate) struct CorePixelVicinity {
     pub top_right: ColorValue,
 }
 
-type Maniac<'a> = ChannelSet<Option<ManiacTree<'a>>>;
-
 // safety criterias defined by `debug_assert`s
-impl DecodingImage {
-    pub fn new(info: &FlifInfo) -> DecodingImage {
+impl<'a, P: PixelTrait, R: Read> DecodingImage<'a, P, R> {
+    pub fn new(
+        info: &'a FlifInfo, rac: &'a mut Rac<R>, limits: &'a Limits,
+        update_table: &'a UpdateTable,
+    ) -> Result<DecodingImage<'a, P, R>> {
         let pixels = (info.header.height * info.header.width) as usize;
-        DecodingImage {
+
+        Ok(DecodingImage {
             height: info.header.height,
             width: info.header.width,
-            channels: info.header.channels,
-            data: vec![Pixel::default(); pixels],
-        }
+            info,
+            rac,
+            update_table,
+            limits,
+            data: vec![P::default(); pixels],
+        })
     }
 
     fn check_data(&self) -> bool {
@@ -66,20 +151,17 @@ impl DecodingImage {
         ((self.width * y) + x) as usize
     }
 
-    pub fn get_data(&self) -> &[Pixel] {
-        &self.data
-    }
-
-    unsafe fn get_val(&self, x: u32, y: u32, chan: Channel) -> ColorValue {
+    unsafe fn get_val(&self, x: u32, y: u32, chan: P::Channels) -> ColorValue {
         debug_assert!(x < self.width && y < self.height && self.check_data());
-        self.data.get_unchecked(self.get_idx(x, y))[chan]
+        self.data.get_unchecked(self.get_idx(x, y)).get_value(chan)
     }
 
-    unsafe fn get_edge_vicinity(&self, x: u32, y: u32, chan: Channel) -> EdgePixelVicinity {
+    unsafe fn get_edge_vicinity(&self, x: u32, y: u32, chan: P::Channels)
+        -> EdgePixelVicinity<P>
+    {
         debug_assert!(x < self.width && y < self.height && self.check_data());
         EdgePixelVicinity {
             pixel: *self.data.get_unchecked(self.get_idx(x, y)),
-            is_rgba: self.channels == ColorSpace::RGBA,
             chan,
             top: if y != 0 {
                 Some(self.get_val(x, y - 1, chan))
@@ -114,12 +196,13 @@ impl DecodingImage {
         }
     }
 
-    unsafe fn get_core_vicinity(&self, x: u32, y: u32, chan: Channel) -> CorePixelVicinity {
+    unsafe fn get_core_vicinity(&self, x: u32, y: u32, chan: P::Channels)
+        -> CorePixelVicinity<P>
+    {
         debug_assert!(x < self.width - 1 && y < self.height && x > 1 && y > 1 && self.check_data());
         CorePixelVicinity {
             pixel: *self.data.get_unchecked(self.get_idx(x, y)),
             chan,
-            is_rgba: self.channels == ColorSpace::RGBA,
             top: self.get_val(x, y - 1, chan),
             left: self.get_val(x - 1, y, chan),
             left2: self.get_val(x - 2, y, chan),
@@ -129,40 +212,102 @@ impl DecodingImage {
         }
     }
 
-    unsafe fn process_edge_pixel<E, R: Read>(
+    unsafe fn process_edge_pixel(
         &mut self,
         x: u32,
         y: u32,
-        chan: Channel,
-        maniac: &mut Maniac,
-        rac: &mut Rac<R>,
-        mut edge_f: E,
+        chan: P::Channels,
+        maniac: &mut Option<ManiacTree<'a>>,
     ) -> Result<()>
-    where
-        E: FnMut(EdgePixelVicinity, &mut Maniac, &mut Rac<R>) -> Result<ColorValue>,
     {
-        debug_assert!(x < self.width && y < self.height && self.check_data());
-        let pix_vic = self.get_edge_vicinity(x, y, chan);
-        let val = edge_f(pix_vic, maniac, rac)?;
+        let vic = self.get_edge_vicinity(x, y, chan);
+
+        let guess = make_edge_guess(self.info, &vic);
+        let c = chan.as_channel();
+        let pix = vic.pixel.to_rgba();
+        let range = self.info.transform.crange(c, pix);
+        let snap = self.info.transform.snap(c, pix, guess);
+        let pvec = edge_pvec(snap, &vic);
+
+        let val = if let Some(ref mut maniac) = maniac {
+            maniac.process(self.rac, &pvec, snap, range.min, range.max)?
+        } else {
+            range.min
+        };
+
+
         let idx = self.get_idx(x, y);
-        self.data.get_unchecked_mut(idx)[chan] = val;
+        self.data.get_unchecked_mut(idx).set_value(val, chan);
         Ok(())
     }
 
-    // iterate over all image pixels and call closure for them without any
-    // bound checks
-    pub fn channel_pass<E, F, R: Read>(
+    unsafe fn process_core_pixel(
         &mut self,
-        chan: Channel,
-        maniac: &mut Maniac,
-        rac: &mut Rac<R>,
-        mut edge_f: E,
-        mut core_f: F,
+        x: u32,
+        y: u32,
+        chan: P::Channels,
+        maniac: &mut Option<ManiacTree<'a>>,
     ) -> Result<()>
-    where
-        E: FnMut(EdgePixelVicinity, &mut Maniac, &mut Rac<R>) -> Result<ColorValue>,
-        F: FnMut(CorePixelVicinity, &mut Maniac, &mut Rac<R>) -> Result<ColorValue>,
     {
+        let vic = self.get_core_vicinity(x, y, chan);
+
+        let guess = make_core_guess(&vic);
+        let c = chan.as_channel();
+        let pix = vic.pixel.to_rgba();
+        let range = self.info.transform.crange(c, pix);
+        let snap = self.info.transform.snap(c, pix, guess);
+        let pvec = core_pvec(snap, &vic);
+
+        let val = if let Some(ref mut maniac) = maniac {
+            maniac.process(self.rac, &pvec, snap, range.min, range.max)?
+        } else {
+            range.min
+        };
+
+
+        let idx = self.get_idx(x, y);
+        self.data.get_unchecked_mut(idx).set_value(val, chan);
+        Ok(())
+    }
+
+    pub fn process(&mut self) -> Result<Box<[u8]>> {
+        let channels = P::get_chan_order();
+        let mut maniac: [Option<ManiacTree>; 4] = Default::default();
+        for (i, chan) in channels.as_ref().iter().enumerate() {
+            let channel = chan.as_channel();
+            let range = self.info.transform.range(channel);
+            if range.min == range.max {
+                maniac[i] = None;
+            } else {
+                let tree = ManiacTree::new(
+                    self.rac,
+                    channel,
+                    self.info,
+                    self.update_table,
+                    self.limits,
+                )?;
+                maniac[i] = Some(tree);
+            }
+        }
+
+        for (chan, tree) in channels.as_ref().iter().zip(maniac.iter_mut()) {
+            self.channel_pass(*chan, tree)?;
+        }
+
+        // undo transofrms and copy raw data
+        let n = P::size();
+        let mut raw = Vec::with_capacity(n*self.data.len());
+        for pixel in self.data.iter_mut() {
+            let rgba = self.info.transform.undo(pixel.to_rgba());
+            raw.extend(rgba[..n].iter().map(|v| *v as u8 ));
+        }
+
+        Ok(raw.into_boxed_slice())
+    }
+
+    fn channel_pass(
+        &mut self, chan: P::Channels, maniac: &mut Option<ManiacTree<'a>>
+    ) -> Result<()> {
         let width = self.width;
         let height = self.height;
         debug_assert!(self.check_data());
@@ -170,7 +315,7 @@ impl DecodingImage {
         if width <= 3 || height <= 2 {
             for y in 0..height {
                 for x in 0..width {
-                    unsafe { self.process_edge_pixel(x, y, chan, maniac, rac, &mut edge_f)? }
+                    unsafe { self.process_edge_pixel(x, y, chan, maniac)? }
                 }
             }
             return Ok(());
@@ -179,7 +324,7 @@ impl DecodingImage {
         for y in 0..2 {
             for x in 0..width {
                 unsafe {
-                    self.process_edge_pixel(x, y, chan, maniac, rac, &mut edge_f)?;
+                    self.process_edge_pixel(x, y, chan, maniac)?;
                 }
             }
         }
@@ -187,24 +332,59 @@ impl DecodingImage {
         for y in 2..height {
             // safe because we are sure that x and y inside the image
             unsafe {
-                self.process_edge_pixel(0, y, chan, maniac, rac, &mut edge_f)?;
-                self.process_edge_pixel(1, y, chan, maniac, rac, &mut edge_f)?;
+                self.process_edge_pixel(0, y, chan, maniac)?;
+                self.process_edge_pixel(1, y, chan, maniac)?;
                 let end = width - 1;
                 for x in 2..end {
-                    let pix_vic = self.get_core_vicinity(x, y, chan);
-                    let val = core_f(pix_vic, maniac, rac)?;
-                    let idx = self.get_idx(x, y);
-                    self.data.get_unchecked_mut(idx)[chan] = val;
+                    self.process_core_pixel(x, y, chan, maniac)?;
                 }
-                self.process_edge_pixel(end, y, chan, maniac, rac, &mut edge_f)?;
+                self.process_edge_pixel(end, y, chan, maniac)?;
             }
         }
         Ok(())
     }
+}
 
-    pub fn undo_transform(&mut self, transform: &Transform) {
-        for vals in self.data.iter_mut() {
-            transform.undo(vals);
-        }
-    }
+
+fn make_core_guess<P: PixelTrait>(pix_vic: &CorePixelVicinity<P>) -> i16 {
+    let left = pix_vic.left;
+    let top = pix_vic.top;
+    let top_left = pix_vic.top_left;
+
+    median3(left + top - top_left, left, top)
+}
+
+pub(crate) fn make_edge_guess<P>(info: &FlifInfo, vic: &EdgePixelVicinity<P>) -> i16
+    where P: PixelTrait, P::Channels: ChannelsTrait
+{
+    let transformation = &info.transform;
+
+    let left = if let Some(val) = vic.left {
+        val
+    } else if let Some(val) = vic.top {
+        val
+    } else if info.second_header.alpha_zero &&
+        !vic.chan.is_alpha() && vic.pixel.is_alpha_zero()
+    {
+        let chan = vic.chan.as_channel();
+        (transformation.range(chan).min + transformation.range(chan).max) / 2
+    } else {
+        transformation.range(vic.chan.as_channel()).min
+    };
+
+    let top = if let Some(val) = vic.top {
+        val
+    } else {
+        left
+    };
+
+    let top_left = if let Some(val) = vic.top_left {
+        val
+    } else if let Some(val) = vic.top {
+        val
+    } else {
+        left
+    };
+
+    median3(left + top - top_left, left, top)
 }

--- a/flif/src/decoding_image.rs
+++ b/flif/src/decoding_image.rs
@@ -9,10 +9,10 @@ use numbers::median3;
 use numbers::chances::UpdateTable;
 use {FlifInfo, Limits};
 
-use pixels::{PixelTrait, ChannelsTrait};
+use pixels::{Pixel, ChannelsTrait};
 pub use decoder::Decoder;
 
-pub(crate) struct DecodingImage<'a, P: PixelTrait, R: Read + 'a> {
+pub(crate) struct DecodingImage<'a, P: Pixel, R: Read + 'a> {
     height: u32,
     width: u32,
     info: &'a FlifInfo,
@@ -23,7 +23,7 @@ pub(crate) struct DecodingImage<'a, P: PixelTrait, R: Read + 'a> {
 }
 
 #[derive(Debug)]
-pub(crate) struct EdgePixelVicinity<P: PixelTrait> {
+pub(crate) struct EdgePixelVicinity<P: Pixel> {
     pub pixel: P,
     pub chan: P::Channels,
     pub left: Option<ColorValue>,
@@ -35,7 +35,7 @@ pub(crate) struct EdgePixelVicinity<P: PixelTrait> {
 }
 
 #[derive(Debug)]
-pub(crate) struct CorePixelVicinity<P: PixelTrait> {
+pub(crate) struct CorePixelVicinity<P: Pixel> {
     pub pixel: P,
     pub chan: P::Channels,
     pub left: ColorValue,
@@ -47,7 +47,7 @@ pub(crate) struct CorePixelVicinity<P: PixelTrait> {
 }
 
 // safety criterias defined by `debug_assert`s
-impl<'a, P: PixelTrait, R: Read> DecodingImage<'a, P, R> {
+impl<'a, P: Pixel, R: Read> DecodingImage<'a, P, R> {
     pub fn new(
         info: &'a FlifInfo, rac: &'a mut Rac<R>, limits: &'a Limits,
         update_table: &'a UpdateTable,
@@ -282,7 +282,7 @@ impl<'a, P: PixelTrait, R: Read> DecodingImage<'a, P, R> {
 }
 
 
-fn make_core_guess<P: PixelTrait>(pix_vic: &CorePixelVicinity<P>) -> i16 {
+fn make_core_guess<P: Pixel>(pix_vic: &CorePixelVicinity<P>) -> i16 {
     let left = pix_vic.left;
     let top = pix_vic.top;
     let top_left = pix_vic.top_left;
@@ -291,7 +291,7 @@ fn make_core_guess<P: PixelTrait>(pix_vic: &CorePixelVicinity<P>) -> i16 {
 }
 
 fn make_edge_guess<P>(info: &FlifInfo, vic: &EdgePixelVicinity<P>) -> i16
-    where P: PixelTrait, P::Channels: ChannelsTrait
+    where P: Pixel, P::Channels: ChannelsTrait
 {
     let transformation = &info.transform;
 

--- a/flif/src/decoding_image.rs
+++ b/flif/src/decoding_image.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-use colors::ColorValue;
+use pixels::ColorValue;
 use components::transformations::Transform;
 pub use error::{Error, Result};
 use maniac::{core_pvec, edge_pvec, ManiacTree};
@@ -235,7 +235,7 @@ impl<'a, P: Pixel, R: Read> DecodingImage<'a, P, R> {
         let mut raw = Vec::with_capacity(n*self.data.len());
         for pixel in self.data.iter_mut() {
             let rgba = self.info.transform.undo(pixel.to_rgba());
-            raw.extend(rgba[..n].iter().map(|v| *v as u8 ));
+            raw.extend(rgba.0[..n].iter().map(|v| *v as u8 ));
         }
 
         Ok(raw.into_boxed_slice())

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -35,6 +35,7 @@ mod decoding_image;
 mod error;
 mod maniac;
 mod numbers;
+mod pixels;
 
 pub struct Flif {
     info: FlifInfo,

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -55,7 +55,7 @@ impl Flif {
         &self.info
     }
 
-    // deprecate?
+    #[deprecated(since="0.3.1", note="please use `raw` and `into_raw` instead")]
     pub fn get_raw_pixels(&self) -> Vec<u8> {
         self.raw.to_vec()
     }

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -63,6 +63,10 @@ impl Flif {
     pub fn raw(&self) -> &Box<[u8]> {
         &self.raw
     }
+
+    pub fn into_raw(self) -> Box<[u8]> {
+        self.raw
+    }
 }
 
 /// Limits on input images to prevent OOM based DoS

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -15,13 +15,11 @@
 //!     let raw_pixels = image.get_raw_pixels();
 //! }
 //! ```
-extern crate fnv;
 extern crate inflate;
 extern crate num_traits;
 
 use std::io::Read;
 
-use colors::ColorSpace;
 use components::header::{Header, SecondHeader};
 use components::metadata::Metadata;
 use components::transformations::Transform;
@@ -40,7 +38,7 @@ mod numbers;
 
 pub struct Flif {
     info: FlifInfo,
-    image_data: DecodingImage,
+    raw: Box<[u8]>,
 }
 
 impl Flif {
@@ -56,23 +54,13 @@ impl Flif {
         &self.info
     }
 
+    // deprecate?
     pub fn get_raw_pixels(&self) -> Vec<u8> {
-        let n = match self.info.header.channels {
-            ColorSpace::RGBA => 4,
-            ColorSpace::RGB => 3,
-            ColorSpace::Monochrome => 1,
-        };
-        let width = self.info.header.width;
-        let height = self.info.header.height;
-        let mut data = Vec::with_capacity((n * width * height) as usize);
+        self.raw.to_vec()
+    }
 
-        for vals in self.image_data.get_data().iter() {
-            for channel in self.info.header.channels {
-                data.push(vals[channel] as u8)
-            }
-        }
-
-        data
+    pub fn raw(&self) -> &Box<[u8]> {
+        &self.raw
     }
 }
 

--- a/flif/src/lib.rs
+++ b/flif/src/lib.rs
@@ -66,7 +66,7 @@ impl Flif {
 }
 
 /// Limits on input images to prevent OOM based DoS
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Limits {
     /// max size of the compressed metadata in bytes (default: 1 MB)
     pub metadata_chunk: u32,

--- a/flif/src/maniac/mod.rs
+++ b/flif/src/maniac/mod.rs
@@ -2,10 +2,10 @@
 
 use std::io::Read;
 
-use colors::{Channel, ColorSpace, ColorValue};
 use components::transformations::ColorRange;
 use components::transformations::Transform;
 use error::*;
+use pixels::{RgbaChannels, ColorSpace, ColorValue};
 use numbers::chances::{ChanceTable, UpdateTable};
 use numbers::near_zero::NearZeroCoder;
 use numbers::rac::{Rac, RacRead};
@@ -23,7 +23,7 @@ pub struct ManiacTree<'a> {
 impl<'a> ManiacTree<'a> {
     pub fn new<R: Read>(
         rac: &mut Rac<R>,
-        channel: Channel,
+        channel: RgbaChannels,
         info: &FlifInfo,
         update_table: &'a UpdateTable,
         limits: &Limits,
@@ -295,21 +295,21 @@ impl<'a> ManiacTree<'a> {
         }
     }
 
-    fn build_prange_vec(channel: Channel, info: &FlifInfo) -> Vec<ColorRange> {
+    fn build_prange_vec(channel: RgbaChannels, info: &FlifInfo) -> Vec<ColorRange> {
         let mut prange = Vec::new();
 
         let transform = &info.transform;
 
-        if channel == Channel::Green || channel == Channel::Blue {
-            prange.push(transform.range(Channel::Red));
+        if channel == RgbaChannels::Green || channel == RgbaChannels::Blue {
+            prange.push(transform.range(RgbaChannels::Red));
         }
 
-        if channel == Channel::Blue {
-            prange.push(transform.range(Channel::Green));
+        if channel == RgbaChannels::Blue {
+            prange.push(transform.range(RgbaChannels::Green));
         }
 
-        if channel != Channel::Alpha && info.header.channels == ColorSpace::RGBA {
-            prange.push(transform.range(Channel::Alpha));
+        if channel != RgbaChannels::Alpha && info.header.channels == ColorSpace::RGBA {
+            prange.push(transform.range(RgbaChannels::Alpha));
         }
 
         prange.push(transform.range(channel));

--- a/flif/src/maniac/pvec.rs
+++ b/flif/src/maniac/pvec.rs
@@ -1,10 +1,10 @@
 use colors::{Channel, ColorSpace, ColorValue};
 use decoding_image::{CorePixelVicinity, EdgePixelVicinity};
-use pixels::PixelTrait;
+use pixels::Pixel;
 
 type Pvec = [ColorValue; 11];
 
-pub(crate) fn core_pvec<P: PixelTrait>(pred: ColorValue, pvic: &CorePixelVicinity<P>) -> Pvec {
+pub(crate) fn core_pvec<P: Pixel>(pred: ColorValue, pvic: &CorePixelVicinity<P>) -> Pvec {
     let mut pvec = [0; 11];
     let mut i = 0;
 
@@ -47,7 +47,7 @@ pub(crate) fn core_pvec<P: PixelTrait>(pred: ColorValue, pvic: &CorePixelVicinit
     pvec
 }
 
-pub(crate) fn edge_pvec<P: PixelTrait>(pred: ColorValue, pvic: &EdgePixelVicinity<P>) -> Pvec {
+pub(crate) fn edge_pvec<P: Pixel>(pred: ColorValue, pvic: &EdgePixelVicinity<P>) -> Pvec {
     let mut pvec = [0; 11];
     let mut i = 0;
 

--- a/flif/src/maniac/pvec.rs
+++ b/flif/src/maniac/pvec.rs
@@ -1,25 +1,25 @@
 use colors::{Channel, ColorSpace, ColorValue};
-use decoding_image::{CorePixelVicinity, EdgePixelVicinity};
+use decoding_image::{CorePixelVicinity, EdgePixelVicinity, PixelTrait};
 
 type Pvec = [ColorValue; 11];
 
-pub(crate) fn core_pvec(pred: ColorValue, pvic: &CorePixelVicinity) -> Pvec {
+pub(crate) fn core_pvec<P: PixelTrait>(pred: ColorValue, pvic: &CorePixelVicinity<P>) -> Pvec {
     let mut pvec = [0; 11];
     let mut i = 0;
 
     let chan = pvic.chan;
-    if chan == Channel::Green || chan == Channel::Blue {
-        pvec[i] = pvic.pixel[Channel::Red];
+    if let Some(val) = pvic.pixel.get_red_pvec(chan) {
+        pvec[i] = val;
         i += 1;
     }
 
-    if chan == Channel::Blue {
-        pvec[i] = pvic.pixel[Channel::Green];
+    if let Some(val) = pvic.pixel.get_green_pvec(chan) {
+        pvec[i] = val;
         i += 1;
     }
 
-    if chan != Channel::Alpha && pvic.is_rgba {
-        pvec[i] = pvic.pixel[Channel::Alpha];
+    if let Some(val) = pvic.pixel.get_alpha_pvec(chan) {
+        pvec[i] = val;
         i += 1;
     }
 
@@ -46,23 +46,23 @@ pub(crate) fn core_pvec(pred: ColorValue, pvic: &CorePixelVicinity) -> Pvec {
     pvec
 }
 
-pub(crate) fn edge_pvec(pred: ColorValue, pvic: &EdgePixelVicinity) -> Pvec {
+pub(crate) fn edge_pvec<P: PixelTrait>(pred: ColorValue, pvic: &EdgePixelVicinity<P>) -> Pvec {
     let mut pvec = [0; 11];
     let mut i = 0;
 
     let chan = pvic.chan;
-    if chan == Channel::Green || chan == Channel::Blue {
-        pvec[i] = pvic.pixel[Channel::Red];
+    if let Some(val) = pvic.pixel.get_red_pvec(chan) {
+        pvec[i] = val;
         i += 1;
     }
 
-    if chan == Channel::Blue {
-        pvec[i] = pvic.pixel[Channel::Green];
+    if let Some(val) = pvic.pixel.get_green_pvec(chan) {
+        pvec[i] = val;
         i += 1;
     }
 
-    if chan != Channel::Alpha && pvic.is_rgba {
-        pvec[i] = pvic.pixel[Channel::Alpha];
+    if let Some(val) = pvic.pixel.get_alpha_pvec(chan) {
+        pvec[i] = val;
         i += 1;
     }
 

--- a/flif/src/maniac/pvec.rs
+++ b/flif/src/maniac/pvec.rs
@@ -1,6 +1,5 @@
-use colors::{Channel, ColorSpace, ColorValue};
+use pixels::{Pixel, ColorSpace, ColorValue};
 use decoding_image::{CorePixelVicinity, EdgePixelVicinity};
-use pixels::Pixel;
 
 type Pvec = [ColorValue; 11];
 

--- a/flif/src/maniac/pvec.rs
+++ b/flif/src/maniac/pvec.rs
@@ -1,10 +1,10 @@
 use pixels::{Pixel, ColorSpace, ColorValue};
 use decoding_image::{CorePixelVicinity, EdgePixelVicinity};
 
-type Pvec = [ColorValue; 11];
+type Pvec = [ColorValue; 10];
 
 pub(crate) fn core_pvec<P: Pixel>(pred: ColorValue, pvic: &CorePixelVicinity<P>) -> Pvec {
-    let mut pvec = [0; 11];
+    let mut pvec = [0; 10];
     let mut i = 0;
 
     let chan = pvic.chan;
@@ -47,7 +47,7 @@ pub(crate) fn core_pvec<P: Pixel>(pred: ColorValue, pvic: &CorePixelVicinity<P>)
 }
 
 pub(crate) fn edge_pvec<P: Pixel>(pred: ColorValue, pvic: &EdgePixelVicinity<P>) -> Pvec {
-    let mut pvec = [0; 11];
+    let mut pvec = [0; 10];
     let mut i = 0;
 
     let chan = pvic.chan;

--- a/flif/src/maniac/pvec.rs
+++ b/flif/src/maniac/pvec.rs
@@ -1,5 +1,6 @@
 use colors::{Channel, ColorSpace, ColorValue};
-use decoding_image::{CorePixelVicinity, EdgePixelVicinity, PixelTrait};
+use decoding_image::{CorePixelVicinity, EdgePixelVicinity};
+use pixels::PixelTrait;
 
 type Pvec = [ColorValue; 11];
 

--- a/flif/src/pixels.rs
+++ b/flif/src/pixels.rs
@@ -5,7 +5,7 @@ pub trait ChannelsTrait {
     fn is_alpha(&self) -> bool;
 }
 
-pub trait PixelTrait: Default + Copy {
+pub trait Pixel: Default + Copy {
     type Channels: ChannelsTrait + Copy;
     type ChanOrder: AsRef<[Self::Channels]>;
 
@@ -43,7 +43,7 @@ impl ChannelsTrait for GreyChannels {
     fn is_alpha(&self) -> bool { false }
 }
 
-impl PixelTrait for Greyscale {
+impl Pixel for Greyscale {
     type Channels = GreyChannels;
     type ChanOrder = [GreyChannels; 1];
 
@@ -99,7 +99,7 @@ impl ChannelsTrait for RgbChannels {
     fn is_alpha(&self) -> bool { false }
 }
 
-impl PixelTrait for Rgb {
+impl Pixel for Rgb {
     type Channels = RgbChannels;
     type ChanOrder = [RgbChannels; 3];
 
@@ -167,7 +167,7 @@ impl ChannelsTrait for RgbaChannels {
     fn is_alpha(&self) -> bool { *self == RgbaChannels::Alpha }
 }
 
-impl PixelTrait for Rgba {
+impl Pixel for Rgba {
     type Channels = RgbaChannels;
     type ChanOrder = [RgbaChannels; 4];
 

--- a/flif/src/pixels.rs
+++ b/flif/src/pixels.rs
@@ -1,0 +1,216 @@
+use colors::{Channel, ColorValue};
+
+pub trait ChannelsTrait {
+    fn as_channel(&self) -> Channel;
+    fn is_alpha(&self) -> bool;
+}
+
+pub trait PixelTrait: Default + Copy {
+    type Channels: ChannelsTrait + Copy;
+    type ChanOrder: AsRef<[Self::Channels]>;
+
+    fn is_rgba() -> bool;
+    fn get_value(&self, chan: Self::Channels) -> ColorValue;
+    fn set_value(&mut self, val: ColorValue, chan: Self::Channels);
+    /// Return if alpha channel equals to zero. For non-RGBA images always
+    /// returns `false`.
+    fn is_alpha_zero(&self) -> bool;
+
+    /// Return red value if chan is green or blue. Always None for greyscale.
+    fn get_red_pvec(&self, chan: Self::Channels) -> Option<ColorValue>;
+    /// Return green value if chan is blue. Always None for greyscale.
+    fn get_green_pvec(&self, chan: Self::Channels) -> Option<ColorValue>;
+    /// Return alpha value if chan is not alpha. Always None for non-RGBA.
+    fn get_alpha_pvec(&self, chan: Self::Channels) -> Option<ColorValue>;
+
+    fn to_rgba(&self) -> [i16; 4];
+    fn get_chan_order() -> Self::ChanOrder;
+    fn size() -> usize;
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Greyscale(i16);
+
+#[derive(Debug, Copy, Clone)]
+pub enum GreyChannels {
+    Grey = 0,
+}
+
+impl ChannelsTrait for GreyChannels {
+    #[inline(always)]
+    fn as_channel(&self) -> Channel { Channel::Red }
+    #[inline(always)]
+    fn is_alpha(&self) -> bool { false }
+}
+
+impl PixelTrait for Greyscale {
+    type Channels = GreyChannels;
+    type ChanOrder = [GreyChannels; 1];
+
+    #[inline(always)]
+    fn is_rgba() -> bool { false }
+    #[inline(always)]
+    fn get_value(&self, _chan: Self::Channels) -> ColorValue { self.0 }
+    #[inline(always)]
+    fn set_value(&mut self, val: ColorValue, _chan: Self::Channels) {
+        self.0 = val;
+    }
+    #[inline(always)]
+    fn is_alpha_zero(&self) -> bool { false }
+    #[inline(always)]
+    fn get_red_pvec(&self, _chan: Self::Channels) -> Option<ColorValue> { None }
+    #[inline(always)]
+    fn get_green_pvec(&self, _chan: Self::Channels) -> Option<ColorValue> {
+        None
+    }
+    #[inline(always)]
+    fn get_alpha_pvec(&self, _chan: Self::Channels) -> Option<ColorValue> {
+        None
+    }
+    #[inline(always)]
+    fn to_rgba(&self) -> [i16; 4] { [self.0, 0, 0, 0] }
+    #[inline(always)]
+    fn get_chan_order() -> Self::ChanOrder { [GreyChannels::Grey] }
+    #[inline(always)]
+    fn size() -> usize { 1 }
+}
+
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Rgb([i16; 3]);
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RgbChannels {
+    Red = 0,
+    Green = 1,
+    Blue = 2,
+}
+
+impl ChannelsTrait for RgbChannels {
+    #[inline(always)]
+    fn as_channel(&self) -> Channel {
+        match self {
+            RgbChannels::Red => Channel::Red,
+            RgbChannels::Green => Channel::Green,
+            RgbChannels::Blue => Channel::Blue,
+        }
+    }
+    #[inline(always)]
+    fn is_alpha(&self) -> bool { false }
+}
+
+impl PixelTrait for Rgb {
+    type Channels = RgbChannels;
+    type ChanOrder = [RgbChannels; 3];
+
+    #[inline(always)]
+    fn is_rgba() -> bool { false }
+    #[inline(always)]
+    fn get_value(&self, chan: Self::Channels) -> ColorValue {
+        self.0[chan as usize]
+    }
+    #[inline(always)]
+    fn set_value(&mut self, val: ColorValue, chan: Self::Channels) {
+        self.0[chan as usize] = val;
+    }
+    #[inline(always)]
+    fn is_alpha_zero(&self) -> bool { false }
+    #[inline(always)]
+    fn get_red_pvec(&self, chan: Self::Channels) -> Option<ColorValue> {
+        if chan == RgbChannels::Green || chan == RgbChannels::Blue {
+            Some(self.0[0])
+        } else {
+            None
+        }
+    }
+    #[inline(always)]
+    fn get_green_pvec(&self, chan: Self::Channels) -> Option<ColorValue> {
+        if chan == RgbChannels::Blue { Some(self.0[1]) } else { None }
+    }
+    #[inline(always)]
+    fn get_alpha_pvec(&self, _chan: Self::Channels) -> Option<ColorValue> {
+        None
+    }
+    #[inline(always)]
+    fn to_rgba(&self) -> [i16; 4] { [self.0[0], self.0[1], self.0[2], 0] }
+    #[inline(always)]
+    fn get_chan_order() -> Self::ChanOrder {
+        [RgbChannels::Red, RgbChannels::Green, RgbChannels::Blue]
+    }
+    #[inline(always)]
+    fn size() -> usize { 3 }
+}
+
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Rgba([i16; 4]);
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RgbaChannels {
+    Red = 0,
+    Green = 1,
+    Blue = 2,
+    Alpha = 3,
+}
+
+impl ChannelsTrait for RgbaChannels {
+    #[inline(always)]
+    fn as_channel(&self) -> Channel {
+        match self {
+            RgbaChannels::Red => Channel::Red,
+            RgbaChannels::Green => Channel::Green,
+            RgbaChannels::Blue => Channel::Blue,
+            RgbaChannels::Alpha => Channel::Alpha,
+        }
+    }
+    #[inline(always)]
+    fn is_alpha(&self) -> bool { *self == RgbaChannels::Alpha }
+}
+
+impl PixelTrait for Rgba {
+    type Channels = RgbaChannels;
+    type ChanOrder = [RgbaChannels; 4];
+
+    #[inline(always)]
+    fn is_rgba() -> bool { true }
+    #[inline(always)]
+    fn get_value(&self, chan: Self::Channels) -> ColorValue {
+        self.0[chan as usize]
+    }
+    #[inline(always)]
+    fn set_value(&mut self, val: ColorValue, chan: Self::Channels) {
+        self.0[chan as usize] = val;
+    }
+    #[inline(always)]
+    fn is_alpha_zero(&self) -> bool { self.0[3] == 0 }
+    #[inline(always)]
+    fn get_red_pvec(&self, chan: Self::Channels) -> Option<ColorValue> {
+        if chan == RgbaChannels::Green || chan == RgbaChannels::Blue {
+            Some(self.0[0])
+        } else {
+            None
+        }
+    }
+    #[inline(always)]
+    fn get_green_pvec(&self, chan: Self::Channels) -> Option<ColorValue> {
+        if chan == RgbaChannels::Blue { Some(self.0[1]) } else { None }
+    }
+    #[inline(always)]
+    fn get_alpha_pvec(&self, chan: Self::Channels) -> Option<ColorValue> {
+        if chan != RgbaChannels::Alpha { Some(self.0[3]) } else { None }
+    }
+    #[inline(always)]
+    fn to_rgba(&self) -> [i16; 4] { self.0 }
+    #[inline(always)]
+    fn get_chan_order() -> Self::ChanOrder {
+        [
+            RgbaChannels::Alpha,
+            RgbaChannels::Red,
+            RgbaChannels::Green,
+            RgbaChannels::Blue,
+        ]
+    }
+    #[inline(always)]
+    fn size() -> usize { 4 }
+}
+

--- a/flif/tests/invalid_inputs.rs
+++ b/flif/tests/invalid_inputs.rs
@@ -27,7 +27,7 @@ fn ycocg_stack_overflow() {
         pixels: 1 << 16,
         maniac_nodes: 512,
     };
-    let _ = Flif::decode_with_limits(bytes.as_ref(), limits).map(|img| img.get_raw_pixels());
+    let _ = Flif::decode_with_limits(bytes.as_ref(), limits).map(|img| img.into_raw());
 }
 
 /// Tests an issue found in [#34](https://github.com/dgriffen/flif.rs/issues/34)

--- a/flif/tests/png_equality.rs
+++ b/flif/tests/png_equality.rs
@@ -18,9 +18,8 @@ fn sea_snail() {
 
     let file = BufReader::new(File::open("../resources/sea_snail.flif").unwrap());
     let image = Flif::decode(file).unwrap();
-    let data = image.get_raw_pixels();
 
-    assert_eq!(buf, data);
+    assert_eq!(buf, &image.raw()[..]);
 }
 
 #[test]
@@ -35,9 +34,8 @@ fn sea_snail_cutout() {
 
     let file = BufReader::new(File::open("../resources/sea_snail_cutout.flif").unwrap());
     let image = Flif::decode(file).unwrap();
-    let data = image.get_raw_pixels();
 
-    assert_eq!(buf, data);
+    assert_eq!(buf, &image.raw()[..]);
 }
 
 #[test]
@@ -52,9 +50,8 @@ fn flif_logo() {
 
     let file = BufReader::new(File::open("../resources/flif_logo.flif").unwrap());
     let image = Flif::decode(file).unwrap();
-    let data = image.get_raw_pixels();
 
-    assert_eq!(buf, data);
+    assert_eq!(buf, &image.raw()[..]);
 }
 
 #[test]
@@ -69,7 +66,6 @@ fn road() {
 
     let file = BufReader::new(File::open("../resources/road.flif").unwrap());
     let image = Flif::decode(file).unwrap();
-    let data = image.get_raw_pixels();
 
-    assert_eq!(buf, data);
+    assert_eq!(buf, &image.raw()[..]);
 }

--- a/fuzz/fuzz_targets/fuzz_flif.rs
+++ b/fuzz/fuzz_targets/fuzz_flif.rs
@@ -12,5 +12,5 @@ fuzz_target!(|data: &[u8]| {
         maniac_nodes: 512,
     };
     let _ = flif::Flif::decode_with_limits(Cursor::new(data), limits)
-        .map(|img| img.get_raw_pixels());
+        .map(|img| img.into_raw());
 });


### PR DESCRIPTION
This PR improves performance by ~15-20%. The main change is in `DecodingImage`, now it is generic over pixel type as was proposed in #23 . Also I've removed elements required for 16 bit images from `ChanceTable`. Either way, support of 16 bit images will require some redesign of the current code, so I don't see any reasons why why should keep it right now. It allows us to drop `fnv` dependency and reduce number of allocations. it also makes `ManiacNode` smaller, now it's size equals to 96 bytes, it's probably possible to make it even smaller, but my quick attempts didn't produce measurable performance improvement.

Also I've added a new `Flif::raw(&self) -> &Box<[u8]>` method in addition to existing `get_raw_pixels`, the latter probably can be marked with `#[deprecated]` attribute. Other than that public API is left intact.

Comparison with `libflif`:
```
test bench_cutout_full_decode ... bench:   6,434,378 ns/iter (+/- 109,096)
test bench_grey_decode        ... bench:   6,076,588 ns/iter (+/- 182,748)
// libflif benchmark
test libflif_cutout_full_decode ... bench:   5,390,452 ns/iter (+/- 151,733)
test libflif_grey_decode        ... bench:   5,060,798 ns/iter (+/- 65,122)
```
In other words with this PR we are ~20% behind in terms of performance.