### PR TITLE
test against rust 1.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.26.0
 env:
 
 matrix:
@@ -14,6 +15,7 @@ matrix:
       env:
     - rust: nightly
       env: RUSTFMT=true
+    - rust: 1.26.0
 
 before_script:
 - |


### PR DESCRIPTION
This adds a CI test against the currently minimum supported Rust version. I've allowed failures for this build since I don't plan on enforcing a hard requirement on compiler versions yet. This test just lets us know if we need to bump the major version before a release.